### PR TITLE
feat: include raw output preview in JSON parse error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ typings/
 # dotenv environment variables file
 .env
 .actrc
+
+# Claude Code commands
+.claude/

--- a/phpcs-server/src/linter-utils.ts
+++ b/phpcs-server/src/linter-utils.ts
@@ -6,6 +6,7 @@
 
 import * as mm from 'micromatch';
 import * as semver from 'semver';
+import * as strings from './base/common/strings';
 import CharCode from './base/common/charcode';
 import { StringResources as SR } from './strings';
 import { PhpcsMessage } from './message';
@@ -100,16 +101,69 @@ export function shouldIgnoreFile(filePath: string, patterns: string[]): boolean 
 }
 
 /**
+ * Maximum characters to include in error preview.
+ */
+const OUTPUT_PREVIEW_MAX_LENGTH = 500;
+
+/**
+ * Create a preview of raw output for error messages.
+ * @param text The raw output text
+ * @param maxLength Maximum characters to include
+ * @returns Truncated preview with indicator if truncated
+ */
+function createOutputPreview(text: string, maxLength: number = OUTPUT_PREVIEW_MAX_LENGTH): string {
+	if (text.length <= maxLength) {
+		return text;
+	}
+	return text.substring(0, maxLength) + '... [truncated]';
+}
+
+/**
+ * Context information for PHPCS execution diagnostics.
+ */
+export interface PhpcsExecutionContext {
+	exitCode: number | null;
+	signal: string | null;
+	stderr: string;
+}
+
+/**
  * Parse PHPCS JSON output.
  * @param text The raw JSON output from PHPCS
+ * @param context Optional execution context for better error diagnostics
  * @returns Parsed result object
- * @throws Error if JSON is invalid
+ * @throws Error if JSON is invalid, including a preview of the raw output
  */
-export function parsePhpcsOutput(text: string): PhpcsParseResult {
+export function parsePhpcsOutput(text: string, context?: PhpcsExecutionContext): PhpcsParseResult {
 	try {
 		return JSON.parse(text) as PhpcsParseResult;
 	} catch (error) {
-		throw new Error(SR.InvalidJsonStringError);
+		let errorMessage: string;
+
+		if (text.length === 0) {
+			// Empty output - provide execution context
+			const parts: string[] = ['PHPCS returned empty output.'];
+
+			if (context) {
+				if (context.signal) {
+					parts.push(`Process was killed by signal: ${context.signal}`);
+				} else if (context.exitCode !== null && context.exitCode !== 0) {
+					parts.push(`Exit code: ${context.exitCode}`);
+				}
+				if (context.stderr) {
+					parts.push(`STDERR: ${createOutputPreview(context.stderr)}`);
+				}
+			}
+
+			parts.push('This may indicate a timeout, memory limit, or crash.');
+			errorMessage = parts.join(' ');
+		} else {
+			// Non-empty but invalid JSON
+			const preview = createOutputPreview(text);
+			errorMessage = strings.format(SR.InvalidJsonStringErrorWithPreview, text.length.toString(), preview);
+		}
+
+		throw new Error(errorMessage);
 	}
 }
 

--- a/phpcs-server/src/linter.ts
+++ b/phpcs-server/src/linter.ts
@@ -30,6 +30,7 @@ import {
 	parsePhpcsOutput,
 	prepareFileText,
 	shouldIgnoreFile,
+	PhpcsExecutionContext,
 } from "./linter-utils";
 
 // Re-export for backward compatibility
@@ -193,6 +194,14 @@ export class PhpcsLinter {
 		const stdout = (phpcs.stdout ?? '').toString().trim();
 		const stderr = (phpcs.stderr ?? '').toString().trim();
 		const exitCode = phpcs.status;
+		const signal = phpcs.signal;
+
+		// Build execution context for diagnostics
+		const executionContext: PhpcsExecutionContext = {
+			exitCode,
+			signal,
+			stderr,
+		};
 
 		// Handle PHPCS v4+ exit codes first.
 		if (this.isV4OrAbove()) {
@@ -228,7 +237,7 @@ export class PhpcsLinter {
 		}
 
 		// Parse PHPCS output
-		const data = parsePhpcsOutput(stdout);
+		const data = parsePhpcsOutput(stdout, executionContext);
 
 		// Get messages from the appropriate file key
 		let messages;

--- a/phpcs-server/src/strings.ts
+++ b/phpcs-server/src/strings.ts
@@ -20,7 +20,8 @@ export class StringResources {
 
 	static readonly UnknownExecutionError: string = 'Unknown error ocurred. Please verify that {0} returns a valid json object.';
 	static readonly CodingStandardNotInstalledError: string = 'The "{0}" coding standard is not installed. Please review your configuration an try again.';
-	static readonly InvalidJsonStringError: string = 'The phpcs report contains invalid json. Please review "Diagnosing Common Errors" in the plugin README';
+	static readonly InvalidJsonStringError: string = 'The phpcs report contains invalid json. Please review "Diagnosing Common Errors" in the plugin README.';
+	static readonly InvalidJsonStringErrorWithPreview: string = 'The phpcs report contains invalid json. Raw output preview ({0} chars total):\n{1}';
 
 	// PHPCS v4 specific error messages
 	static readonly ProcessingError: string = 'PHPCS encountered a processing error (exit code 16). Please check your ruleset configuration.';

--- a/phpcs-server/test/linter-utils.test.ts
+++ b/phpcs-server/test/linter-utils.test.ts
@@ -17,6 +17,7 @@ import {
 	getV4ExitCodeError,
 	isIgnorePatternMatch,
 	parsePhpcsOutput,
+	PhpcsExecutionContext,
 	prepareFileText,
 	shouldIgnoreFile,
 	transformIgnorePattern,
@@ -105,12 +106,72 @@ suite('Linter Utils', () => {
 			assert.deepStrictEqual(result.files, {});
 		});
 
-		test('should throw on invalid JSON', () => {
-			assert.throws(() => parsePhpcsOutput('invalid'), /invalid json/i);
+		test('should throw on invalid JSON with raw output preview', () => {
+			const invalidInput = 'this is not valid json';
+			assert.throws(
+				() => parsePhpcsOutput(invalidInput),
+				(error: Error) => {
+					return error.message.includes('invalid json') &&
+						error.message.includes(invalidInput) &&
+						error.message.includes('22 chars total');
+				}
+			);
 		});
 
-		test('should throw on empty string', () => {
-			assert.throws(() => parsePhpcsOutput(''), /invalid json/i);
+		test('should throw on empty string with context info', () => {
+			assert.throws(
+				() => parsePhpcsOutput(''),
+				(error: Error) => {
+					return error.message.includes('PHPCS returned empty output') &&
+						error.message.includes('timeout, memory limit, or crash');
+				}
+			);
+		});
+
+		test('should include exit code in empty output error', () => {
+			const context: PhpcsExecutionContext = { exitCode: 255, signal: null, stderr: '' };
+			assert.throws(
+				() => parsePhpcsOutput('', context),
+				(error: Error) => {
+					return error.message.includes('PHPCS returned empty output') &&
+						error.message.includes('Exit code: 255');
+				}
+			);
+		});
+
+		test('should include signal in empty output error', () => {
+			const context: PhpcsExecutionContext = { exitCode: null, signal: 'SIGKILL', stderr: '' };
+			assert.throws(
+				() => parsePhpcsOutput('', context),
+				(error: Error) => {
+					return error.message.includes('PHPCS returned empty output') &&
+						error.message.includes('killed by signal: SIGKILL');
+				}
+			);
+		});
+
+		test('should include stderr in empty output error', () => {
+			const context: PhpcsExecutionContext = { exitCode: 1, signal: null, stderr: 'PHP Fatal error: Allowed memory size exhausted' };
+			assert.throws(
+				() => parsePhpcsOutput('', context),
+				(error: Error) => {
+					return error.message.includes('PHPCS returned empty output') &&
+						error.message.includes('STDERR: PHP Fatal error');
+				}
+			);
+		});
+
+		test('should truncate long output in error preview', () => {
+			const longInvalidInput = 'x'.repeat(600);
+			assert.throws(
+				() => parsePhpcsOutput(longInvalidInput),
+				(error: Error) => {
+					return error.message.includes('invalid json') &&
+						error.message.includes('600 chars total') &&
+						error.message.includes('... [truncated]') &&
+						!error.message.includes('x'.repeat(600));
+				}
+			);
 		});
 
 		test('should parse STDIN key', () => {


### PR DESCRIPTION
## Summary

- Enhanced error messages when PHPCS returns invalid JSON to include a preview of the raw output
- Added new parameterized error message string for detailed diagnostics  
- Updated tests to verify the new error message format and truncation behavior

Closes #8

## Test plan

- [x] Unit tests pass for new error message format
- [x] Tests verify output preview is included in error
- [x] Tests verify long output is properly truncated at 500 chars
- [ ] Manual testing with a file that causes PHPCS to output invalid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error diagnostics for malformed or empty tool output: messages include a truncated preview, total-character counts, and richer hints when output is empty (including exit/termination and stderr details).

* **Tests**
  * Added tests validating enhanced error messages, truncation behavior, and inclusion of execution context in diagnostics.

* **Chores**
  * Updated ignore rules to exclude local tool state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->