### PR TITLE
fix: implement phpcbfOnSave functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "phpcs",
   "description": "PHP CodeSniffer for Visual Studio Code",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Ioannis Kappas",
   "publisher": "johnrdorazio",
   "contributors": [

--- a/phpcs-server/package.json
+++ b/phpcs-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "phpcs-server",
   "description": "PHP Code Sniffer server.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Ioannis Kappas",
   "publisher": "johnrdorazio",
   "contributors": [

--- a/phpcs-server/src/server.ts
+++ b/phpcs-server/src/server.ts
@@ -22,6 +22,8 @@ import {
 	TextDocumentIdentifier,
 	TextDocuments,
 	TextDocumentSyncKind,
+	TextEdit,
+	WillSaveTextDocumentParams,
 	WorkspaceFoldersChangeEvent,
 } from 'vscode-languageserver/node';
 
@@ -96,6 +98,7 @@ class PhpcsServer {
 		this.connection.onDidChangeWatchedFiles(this.safeEventHandler(this.onDidChangeWatchedFiles));
 		this.connection.onCodeAction(this.safeEventHandler(this.onCodeAction));
 		this.connection.onExecuteCommand(this.safeEventHandler(this.onExecuteCommand));
+		this.connection.onWillSaveTextDocumentWaitUntil(this.safeEventHandler(this.onWillSaveTextDocument));
 		this.documents.onDidChangeContent(this.safeEventHandler(this.onDidChangeDocument));
 		this.documents.onDidOpen(this.safeEventHandler(this.onDidOpenDocument));
 		this.documents.onDidSave(this.safeEventHandler(this.onDidSaveDocument));
@@ -126,7 +129,12 @@ class PhpcsServer {
 		this.hasConfigurationCapability = !!(capabilities.workspace && capabilities.workspace.configuration);
 		return Promise.resolve<InitializeResult>({
 			capabilities: {
-				textDocumentSync: TextDocumentSyncKind.Incremental,
+				textDocumentSync: {
+					openClose: true,
+					change: TextDocumentSyncKind.Incremental,
+					willSaveWaitUntil: true,
+					save: { includeText: false },
+				},
 				codeActionProvider: true,
 				executeCommandProvider: {
 					commands: [PHPCBF_FIX_FILE_COMMAND],
@@ -186,6 +194,56 @@ class PhpcsServer {
 		if (settings.lintOnOpen) {
 			await this.validateSingle(document);
 		}
+	}
+
+	/**
+	 * Handles willSave event to apply PHPCBF fixes before saving.
+	 *
+	 * @param params The will save text document parameters.
+	 * @return Text edits to apply before saving, or empty array.
+	 */
+	private async onWillSaveTextDocument(params: WillSaveTextDocumentParams): Promise<TextEdit[]> {
+		const document = this.documents.get(params.textDocument.uri);
+		if (!document) {
+			return [];
+		}
+
+		// Only process PHP files
+		if (document.languageId !== 'php') {
+			return [];
+		}
+
+		const settings = await this.getDocumentSettings(document);
+
+		// Check if PHPCBF on save is enabled
+		if (!settings.phpcbfEnable || !settings.phpcbfOnSave) {
+			return [];
+		}
+
+		// Resolve PHPCBF executable path
+		let phpcbfPath = settings.phpcbfExecutablePath;
+		if (!phpcbfPath && settings.executablePath) {
+			phpcbfPath = settings.executablePath.replace(/phpcs(\.bat|\.phar)?$/i, 'phpcbf$1');
+		}
+
+		if (!phpcbfPath) {
+			return [];
+		}
+
+		try {
+			const fixer = await PhpcbfFixer.create(phpcbfPath);
+			fixer.setLogger((message) => this.connection.console.log(message));
+
+			const result = await fixer.fix(document, settings);
+			if (result.fixed && result.content !== document.getText()) {
+				return [createFullDocumentEdit(document, result.content)];
+			}
+		} catch (error) {
+			// Log error but don't block save
+			this.connection.console.error(`PHPCBF on save failed: ${error}`);
+		}
+
+		return [];
 	}
 
 	/**

--- a/phpcs-server/src/server.ts
+++ b/phpcs-server/src/server.ts
@@ -118,6 +118,24 @@ class PhpcsServer {
 	}
 
 	/**
+	 * Resolve PHPCBF executable path from settings.
+	 *
+	 * @param settings The PHPCS settings.
+	 * @return The resolved PHPCBF path or null.
+	 */
+	private resolvePhpcbfPath(settings: PhpcsSettings): string | null {
+		let phpcbfPath = settings.phpcbfExecutablePath;
+		if (!phpcbfPath && settings.executablePath) {
+			// Try to derive phpcbf path from phpcs path.
+			// Note: This only handles standard naming (phpcs, phpcs.bat, phpcs.phar).
+			// For non-standard names, users should set phpcs.phpcbfExecutablePath explicitly.
+			// The derived path is verified by PhpcbfFixer.create() which throws if invalid.
+			phpcbfPath = settings.executablePath.replace(/phpcs(\.bat|\.phar)?$/i, 'phpcbf$1');
+		}
+		return phpcbfPath || null;
+	}
+
+	/**
 	 * Handles server initialization.
 	 *
 	 * @param params The initialization parameters.
@@ -220,12 +238,7 @@ class PhpcsServer {
 			return [];
 		}
 
-		// Resolve PHPCBF executable path
-		let phpcbfPath = settings.phpcbfExecutablePath;
-		if (!phpcbfPath && settings.executablePath) {
-			phpcbfPath = settings.executablePath.replace(/phpcs(\.bat|\.phar)?$/i, 'phpcbf$1');
-		}
-
+		const phpcbfPath = this.resolvePhpcbfPath(settings);
 		if (!phpcbfPath) {
 			return [];
 		}
@@ -240,7 +253,7 @@ class PhpcsServer {
 			}
 		} catch (error) {
 			// Log error but don't block save
-			this.connection.console.error(`PHPCBF on save failed: ${error}`);
+			this.connection.console.error(strings.format(SR.PhpcbfOnSaveFailed, String(error)));
 		}
 
 		return [];
@@ -362,16 +375,7 @@ class PhpcsServer {
 			return;
 		}
 
-		// Resolve PHPCBF executable path
-		let phpcbfPath = settings.phpcbfExecutablePath;
-		if (!phpcbfPath && settings.executablePath) {
-			// Try to derive phpcbf path from phpcs path.
-			// Note: This only handles standard naming (phpcs, phpcs.bat, phpcs.phar).
-			// For non-standard names, users should set phpcs.phpcbfExecutablePath explicitly.
-			// The derived path is verified by PhpcbfFixer.create() which throws if invalid.
-			phpcbfPath = settings.executablePath.replace(/phpcs(\.bat|\.phar)?$/i, 'phpcbf$1');
-		}
-
+		const phpcbfPath = this.resolvePhpcbfPath(settings);
 		if (!phpcbfPath) {
 			this.connection.window.showWarningMessage(
 				'PHPCBF executable not found. Please set phpcs.phpcbfExecutablePath or ensure phpcbf is alongside phpcs.'

--- a/phpcs-server/src/strings.ts
+++ b/phpcs-server/src/strings.ts
@@ -20,6 +20,7 @@ export class StringResources {
 
 	static readonly CreateFixerErrorDefaultMessage: string = 'Please add phpcbf to your global path or use composer dependency manager to install it in your project locally.';
 	static readonly CreateFixerError: string = 'Unable to locate phpcbf. {0}';
+	static readonly PhpcbfOnSaveFailed: string = 'PHPCBF on save failed: {0}';
 
 	static readonly UnknownExecutionError: string = 'Unknown error ocurred. Please verify that {0} returns a valid json object.';
 	static readonly CodingStandardNotInstalledError: string = 'The "{0}" coding standard is not installed. Please review your configuration an try again.';

--- a/phpcs/CHANGELOG.md
+++ b/phpcs/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the "phpcs" extension will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2025-12-23
+
+### Fixed
+
+- Fixed `phpcs.phpcbfOnSave` setting not working - PHPCBF settings were missing
+  from the client configuration middleware, causing the server to always receive
+  default values instead of user-configured settings
+
+### Changed
+
+- Updated document selector to explicit format for better LSP compatibility
+- Extracted `resolvePhpcbfPath()` helper method to reduce code duplication
+
 ## [1.2.0] - 2025-12-23
 
 ### Added

--- a/phpcs/package.json
+++ b/phpcs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "phpcs",
 	"description": "PHP CodeSniffer for Visual Studio Code",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"author": "Ioannis Kappas",
 	"publisher": "johnrdorazio",
 	"contributors": [

--- a/phpcs/src/configuration.ts
+++ b/phpcs/src/configuration.ts
@@ -99,6 +99,10 @@ export class PhpcsConfiguration extends Disposable {
 				lintOnSave: config.get('lintOnSave'),
 				queueBuffer: config.get('queueBuffer'),
 				lintOnlyOpened: config.get('lintOnlyOpened'),
+				// PHPCBF settings
+				phpcbfEnable: config.get('phpcbfEnable'),
+				phpcbfExecutablePath: config.get('phpcbfExecutablePath'),
+				phpcbfOnSave: config.get('phpcbfOnSave'),
 			};
 
 			settings = await this.resolveExecutablePath(settings);

--- a/phpcs/src/extension.ts
+++ b/phpcs/src/extension.ts
@@ -61,7 +61,7 @@ export function activate(context: ExtensionContext) {
 	// Options to control the language client
 	let clientOptions: LanguageClientOptions = {
 		// Register the server for php documents
-		documentSelector: ["php"],
+		documentSelector: [{ scheme: 'file', language: 'php' }],
 		synchronize: {
 			// Notify the server about file changes to 'ruleset.xml' files contain in the workspace
 			fileEvents: workspace.createFileSystemWatcher("**/ruleset.xml")

--- a/phpcs/src/settings.ts
+++ b/phpcs/src/settings.ts
@@ -22,4 +22,8 @@ export interface PhpcsSettings {
 	lintOnOpen: boolean;
 	queueBuffer: number;
 	lintOnlyOpened: boolean;
+	// PHPCBF settings
+	phpcbfEnable: boolean;
+	phpcbfExecutablePath: string | null;
+	phpcbfOnSave: boolean;
 }


### PR DESCRIPTION
## Summary

- Add `willSaveWaitUntil` capability to the LSP server
- Implement `onWillSaveTextDocument` handler that runs PHPCBF before save
- When `phpcs.phpcbfOnSave` is enabled, PHPCBF fixes are applied before the file is saved

## Test plan

- [x] Enable `phpcs.phpcbfOnSave` in settings
- [x] Introduce a code style violation in a PHP file
- [x] Save the file
- [x] Verify the violation is automatically fixed before save

Fixes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic PHP formatting on file save: PHPCBF fixes can be applied before saving PHP files when enabled; failures are logged and do not block the save.
* **Settings**
  * New options to enable/disable PHPCBF, specify the PHPCBF executable path, and control on-save behavior.
* **Behavior Change**
  * Language server now activates only for file-based PHP documents, reducing unintended triggers.
* **Bug Fixes**
  * On-save PHPCBF settings are now correctly honored.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->