### PR TITLE
feat: PHPCBF post-v1 enhancements with inline diff preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,31 @@ The extension includes support for [PHPCBF](https://github.com/PHPCSStandards/PH
 | `phpcs.phpcbfOnSave`         | boolean | `false` | Auto-fix on save                                                                        |
 | `phpcs.phpcbfSaveOnFix`      | boolean | `false` | Auto-save document after applying fixes                                                 |
 | `phpcs.phpcbfTimeout`        | number  | `60`    | Timeout in seconds for PHPCBF operations                                                |
+
+## Known Issues
+
+### GitHub Copilot Next Edit Suggestions Conflict
+
+If you have GitHub Copilot installed, its "Next Edit Suggestions" feature may
+suggest reverting PHPCBF fixes after you apply them. This happens because Copilot
+learns from code patterns and may suggest "edits" that undo the alignment or
+formatting changes made by PHPCBF.
+
+**Symptoms:**
+
+- After accepting a PHPCBF fix, you see a gutter icon with a checkmark (✓)
+- Hovering shows "Inline Suggestion" with options like "Go To / Accept", "Reject"
+- Accepting the Copilot suggestion reverts the PHPCBF fix
+
+**Solution:**
+
+Disable Copilot's Next Edit Suggestions by adding this to your VS Code settings:
+
+```json
+{
+  "github.copilot.nextEditSuggestions.enabled": false
+}
+```
+
+Alternatively, press `Escape` to dismiss individual Copilot suggestions, or click
+"Snooze" in the suggestion menu to temporarily hide them.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ The extension includes support for [PHPCBF](https://github.com/PHPCSStandards/PH
 - **Quick Fix Actions**: Click on a PHPCS diagnostic (squiggly line) to see three options:
   - "Fix only this issue (PHPCBF)" - fixes just that specific issue immediately
   - "Fix all auto-fixable issues in this file (PHPCBF)" - fixes all issues immediately
-  - "Preview fixes (PHPCBF)" - shows a diff preview before applying changes
+  - "Preview fixes (PHPCBF)" - shows inline diff preview with per-hunk
+    accept/reject actions
 - **Command Palette**: Use "PHPCS: Fix this file with PHPCBF" or "PHPCS: Fix all
   files in workspace with PHPCBF"
 - **Auto-fix on Save**: Enable `phpcs.phpcbfOnSave` to automatically fix issues
@@ -170,9 +171,9 @@ The extension includes support for [PHPCBF](https://github.com/PHPCSStandards/PH
 - **Save on Fix**: Enable `phpcs.phpcbfSaveOnFix` to automatically save the
   document after applying PHPCBF fixes
 - **Diff Preview**: Use the "Preview fixes (PHPCBF)" quick fix action to preview
-  changes before applying them. When `phpcs.phpcbfDiffInline` is enabled, the
-  diff is shown as inline decorations in the current editor instead of a
-  separate diff tab.
+  changes before applying them. Each change is shown with inline decorations and
+  CodeLens actions (Accept, Accept all, Reject, Cancel) allowing you to
+  selectively apply fixes.
 
 ### Settings
 
@@ -182,5 +183,4 @@ The extension includes support for [PHPCBF](https://github.com/PHPCSStandards/PH
 | `phpcs.phpcbfExecutablePath` | string  | `null`  | Path to phpcbf executable (auto-detected if null)                                       |
 | `phpcs.phpcbfOnSave`         | boolean | `false` | Auto-fix on save                                                                        |
 | `phpcs.phpcbfSaveOnFix`      | boolean | `false` | Auto-save document after applying fixes                                                 |
-| `phpcs.phpcbfDiffInline`     | boolean | `false` | Show inline diff decorations instead of separate editor when using "Preview fixes"      |
 | `phpcs.phpcbfTimeout`        | number  | `60`    | Timeout in seconds for PHPCBF operations                                                |

--- a/README.md
+++ b/README.md
@@ -151,3 +151,31 @@ This extension is larger (~650KB uncompressed) compared to simpler alternatives
 
 The trade-off is worth it: the LSP approach ensures VS Code remains responsive
 even when linting large files or projects with many PHP files.
+
+## PHPCBF Integration
+
+The extension includes support for [PHPCBF](https://github.com/PHPCSStandards/PHP_CodeSniffer)
+(PHP Code Beautifier and Fixer) to automatically fix code style issues.
+
+### Features
+
+- **Quick Fix Actions**: Click on a PHPCS diagnostic (squiggly line) and select
+  "Fix this issue (PHPCBF)" or "Fix all auto-fixable issues in this file (PHPCBF)"
+- **Command Palette**: Use "PHPCS: Fix this file with PHPCBF" or "PHPCS: Fix all
+  files in workspace with PHPCBF"
+- **Auto-fix on Save**: Enable `phpcs.phpcbfOnSave` to automatically fix issues
+  when saving a file
+- **Diff Preview**: Enable `phpcs.phpcbfShowDiff` to preview changes before
+  applying them. Use `phpcs.phpcbfDiffInline` to show the diff as inline
+  decorations in the current editor instead of a separate diff tab.
+
+### Settings
+
+| Setting                      | Type    | Default | Description                                             |
+| ---------------------------- | ------- | ------- | ------------------------------------------------------- |
+| `phpcs.phpcbfEnable`         | boolean | `true`  | Enable/disable PHPCBF integration                       |
+| `phpcs.phpcbfExecutablePath` | string  | `null`  | Path to phpcbf executable (auto-detected if null)       |
+| `phpcs.phpcbfOnSave`         | boolean | `false` | Auto-fix on save                                        |
+| `phpcs.phpcbfShowDiff`       | boolean | `false` | Show diff preview before applying fixes                 |
+| `phpcs.phpcbfDiffInline`     | boolean | `false` | Show inline diff decorations instead of separate editor |
+| `phpcs.phpcbfTimeout`        | number  | `60`    | Timeout in seconds for PHPCBF operations                |

--- a/README.md
+++ b/README.md
@@ -159,23 +159,28 @@ The extension includes support for [PHPCBF](https://github.com/PHPCSStandards/PH
 
 ### Features
 
-- **Quick Fix Actions**: Click on a PHPCS diagnostic (squiggly line) and select
-  "Fix this issue (PHPCBF)" or "Fix all auto-fixable issues in this file (PHPCBF)"
+- **Quick Fix Actions**: Click on a PHPCS diagnostic (squiggly line) to see three options:
+  - "Fix only this issue (PHPCBF)" - fixes just that specific issue immediately
+  - "Fix all auto-fixable issues in this file (PHPCBF)" - fixes all issues immediately
+  - "Preview fixes (PHPCBF)" - shows a diff preview before applying changes
 - **Command Palette**: Use "PHPCS: Fix this file with PHPCBF" or "PHPCS: Fix all
   files in workspace with PHPCBF"
 - **Auto-fix on Save**: Enable `phpcs.phpcbfOnSave` to automatically fix issues
   when saving a file
-- **Diff Preview**: Enable `phpcs.phpcbfShowDiff` to preview changes before
-  applying them. Use `phpcs.phpcbfDiffInline` to show the diff as inline
-  decorations in the current editor instead of a separate diff tab.
+- **Save on Fix**: Enable `phpcs.phpcbfSaveOnFix` to automatically save the
+  document after applying PHPCBF fixes
+- **Diff Preview**: Use the "Preview fixes (PHPCBF)" quick fix action to preview
+  changes before applying them. When `phpcs.phpcbfDiffInline` is enabled, the
+  diff is shown as inline decorations in the current editor instead of a
+  separate diff tab.
 
 ### Settings
 
-| Setting                      | Type    | Default | Description                                             |
-| ---------------------------- | ------- | ------- | ------------------------------------------------------- |
-| `phpcs.phpcbfEnable`         | boolean | `true`  | Enable/disable PHPCBF integration                       |
-| `phpcs.phpcbfExecutablePath` | string  | `null`  | Path to phpcbf executable (auto-detected if null)       |
-| `phpcs.phpcbfOnSave`         | boolean | `false` | Auto-fix on save                                        |
-| `phpcs.phpcbfShowDiff`       | boolean | `false` | Show diff preview before applying fixes                 |
-| `phpcs.phpcbfDiffInline`     | boolean | `false` | Show inline diff decorations instead of separate editor |
-| `phpcs.phpcbfTimeout`        | number  | `60`    | Timeout in seconds for PHPCBF operations                |
+| Setting                      | Type    | Default | Description                                                                             |
+| ---------------------------- | ------- | ------- | --------------------------------------------------------------------------------------- |
+| `phpcs.phpcbfEnable`         | boolean | `true`  | Enable/disable PHPCBF integration                                                       |
+| `phpcs.phpcbfExecutablePath` | string  | `null`  | Path to phpcbf executable (auto-detected if null)                                       |
+| `phpcs.phpcbfOnSave`         | boolean | `false` | Auto-fix on save                                                                        |
+| `phpcs.phpcbfSaveOnFix`      | boolean | `false` | Auto-save document after applying fixes                                                 |
+| `phpcs.phpcbfDiffInline`     | boolean | `false` | Show inline diff decorations instead of separate editor when using "Preview fixes"      |
+| `phpcs.phpcbfTimeout`        | number  | `60`    | Timeout in seconds for PHPCBF operations                                                |

--- a/ROADMAP-PHPCBF.md
+++ b/ROADMAP-PHPCBF.md
@@ -41,9 +41,9 @@ Optional setting to auto-fix on save:
 These features are deferred until v1 is stable:
 
 - **Status bar feedback** - Show progress indicator when PHPCBF is running
-  (especially for workspace-wide fixes)
-- **Single diagnostic fixes** - Fix only the specific violation at cursor
-- **Diff preview** - Show changes before applying (optional setting)
+  (especially for workspace-wide fixes) ✅
+- **Single diagnostic fixes** - Fix only the specific violation at cursor ✅
+- **Diff preview** - Show changes before applying (optional setting) ✅
 - **Document formatter registration** - Register as VS Code's document formatter
   (lowest priority, may not implement)
 
@@ -51,12 +51,14 @@ These features are deferred until v1 is stable:
 
 ## New Settings (v1) ✅
 
-| Setting                      | Type    | Default | Description                                       | Status |
-| ---------------------------- | ------- | ------- | ------------------------------------------------- | ------ |
-| `phpcs.phpcbfEnable`         | boolean | `true`  | Enable/disable PHPCBF integration                 | ✅     |
-| `phpcs.phpcbfExecutablePath` | string  | `null`  | Path to phpcbf executable (auto-detected if null) | ✅     |
-| `phpcs.phpcbfOnSave`         | boolean | `false` | Auto-fix on save                                  | ✅     |
-| `phpcs.phpcbfTimeout`        | number  | `60`    | Timeout in seconds for PHPCBF operations          | ✅     |
+| Setting                      | Type    | Default | Description                                             | Status |
+| ---------------------------- | ------- | ------- | ------------------------------------------------------- | ------ |
+| `phpcs.phpcbfEnable`         | boolean | `true`  | Enable/disable PHPCBF integration                       | ✅     |
+| `phpcs.phpcbfExecutablePath` | string  | `null`  | Path to phpcbf executable (auto-detected if null)       | ✅     |
+| `phpcs.phpcbfOnSave`         | boolean | `false` | Auto-fix on save                                        | ✅     |
+| `phpcs.phpcbfShowDiff`       | boolean | `false` | Show diff preview before applying fixes                 | ✅     |
+| `phpcs.phpcbfDiffInline`     | boolean | `false` | Show inline diff decorations instead of separate editor | ✅     |
+| `phpcs.phpcbfTimeout`        | number  | `60`    | Timeout in seconds for PHPCBF operations                | ✅     |
 
 ---
 
@@ -69,6 +71,9 @@ phpcs-server/src/
 ├── fixer.ts              # PhpcbfFixer class (mirrors PhpcsLinter) ✅
 ├── fixer-utils.ts        # Utility functions for PHPCBF operations ✅
 └── code-actions.ts       # Code action provider logic (file-level fixes) ✅
+
+phpcs/src/
+└── diff-provider.ts      # Virtual document provider for diff preview ✅
 
 phpcs-server/test/
 ├── fixer.test.ts         # Integration tests for fixer ✅
@@ -154,16 +159,26 @@ phpcs-server/test/
 
 ## Future Phases (Post-v1)
 
-### Single Diagnostic Fixes
+### Status Bar Feedback ✅
 
-- Add "Fix this issue" action for individual diagnostics
-- May require running PHPCBF with line-specific options or `--dry-run` analysis
+- Show progress indicator when PHPCBF is running
+- Uses wrench icon with spinner animation
+- Tracks multiple concurrent fix operations
 
-### Diff Preview
+### Single Diagnostic Fixes ✅
 
-- Add `phpcs.phpcbfShowDiff` setting
-- Show changes in diff view before applying
-- Allow user to accept/reject
+- Added "Fix this issue (PHPCBF)" action for individual fixable diagnostics
+- Diagnostics now include `fixable` flag from PHPCS output
+- Note: PHPCBF still fixes the entire file, but the action is scoped to the clicked diagnostic
+
+### Diff Preview ✅
+
+- Added `phpcs.phpcbfShowDiff` setting
+- Shows side-by-side diff view before applying changes
+- User can accept or cancel the fix
+- Uses virtual document provider with `phpcbf-preview://` scheme
+- **Inline diff option** (`phpcs.phpcbfDiffInline`): Shows diff decorations in the current editor
+  instead of opening a separate diff tab. Highlights additions in green with line counts.
 
 ### Document Formatter Registration
 

--- a/ROADMAP-PHPCBF.md
+++ b/ROADMAP-PHPCBF.md
@@ -56,8 +56,7 @@ These features are deferred until v1 is stable:
 | `phpcs.phpcbfEnable`         | boolean | `true`  | Enable/disable PHPCBF integration                       | ✅     |
 | `phpcs.phpcbfExecutablePath` | string  | `null`  | Path to phpcbf executable (auto-detected if null)       | ✅     |
 | `phpcs.phpcbfOnSave`         | boolean | `false` | Auto-fix on save                                        | ✅     |
-| `phpcs.phpcbfShowDiff`       | boolean | `false` | Show diff preview before applying fixes                 | ✅     |
-| `phpcs.phpcbfDiffInline`     | boolean | `false` | Show inline diff decorations instead of separate editor | ✅     |
+| `phpcs.phpcbfSaveOnFix`      | boolean | `false` | Auto-save after applying PHPCBF fixes                   | ✅     |
 | `phpcs.phpcbfTimeout`        | number  | `60`    | Timeout in seconds for PHPCBF operations                | ✅     |
 
 ---
@@ -173,12 +172,11 @@ phpcs-server/test/
 
 ### Diff Preview ✅
 
-- Added `phpcs.phpcbfShowDiff` setting
-- Shows side-by-side diff view before applying changes
-- User can accept or cancel the fix
-- Uses virtual document provider with `phpcbf-preview:` scheme
-- **Inline diff option** (`phpcs.phpcbfDiffInline`): Shows diff decorations in the current editor
-  instead of opening a separate diff tab. Highlights additions in green with line counts.
+- "Preview fixes" action in Quick Fix menu shows inline diff preview
+- Per-hunk CodeLens actions: Accept, Accept all, Reject, Cancel
+- Automatically shows remaining fixes after accepting a single change
+- Inline decorations highlight deletions (red) and additions (green)
+- Hover tooltips show replacement content details
 
 ### Document Formatter Registration
 

--- a/ROADMAP-PHPCBF.md
+++ b/ROADMAP-PHPCBF.md
@@ -176,7 +176,7 @@ phpcs-server/test/
 - Added `phpcs.phpcbfShowDiff` setting
 - Shows side-by-side diff view before applying changes
 - User can accept or cancel the fix
-- Uses virtual document provider with `phpcbf-preview://` scheme
+- Uses virtual document provider with `phpcbf-preview:` scheme
 - **Inline diff option** (`phpcs.phpcbfDiffInline`): Shows diff decorations in the current editor
   instead of opening a separate diff tab. Highlights additions in green with line counts.
 

--- a/phpcs-server/src/code-actions.ts
+++ b/phpcs-server/src/code-actions.ts
@@ -104,8 +104,9 @@ export function isDiagnosticFixable(diagnostic: Diagnostic): boolean {
 }
 
 /**
- * Create a "Fix this issue" code action for a fixable diagnostic.
- * Note: PHPCBF will fix all issues in the file, not just this one.
+ * Create a code action for a fixable diagnostic.
+ * Note: PHPCBF operates on the entire file, so this will fix all auto-fixable
+ * issues in the file, not just the specific diagnostic.
  * @param document The text document
  * @param diagnostic The diagnostic to fix
  * @returns A code action for fixing the issue, or null if not fixable
@@ -119,12 +120,12 @@ export function createFixSingleIssueAction(
 	}
 
 	const action: CodeAction = {
-		title: 'Fix this issue (PHPCBF)',
+		title: 'Fix this and other auto-fixable issues (PHPCBF)',
 		kind: CodeActionKind.QuickFix,
 		diagnostics: [diagnostic],
 		isPreferred: false,
 		command: {
-			title: 'Fix with PHPCBF',
+			title: 'Fix file with PHPCBF',
 			command: PHPCBF_FIX_FILE_COMMAND,
 			arguments: [document.uri],
 		},

--- a/phpcs-server/src/code-actions.ts
+++ b/phpcs-server/src/code-actions.ts
@@ -18,6 +18,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
  * Code action command identifiers.
  */
 export const PHPCBF_FIX_FILE_COMMAND = 'phpcs.fixFile';
+export const PHPCBF_FIX_SINGLE_COMMAND = 'phpcs.fixSingleIssue';
 
 /**
  * Data stored in a PHPCS diagnostic.
@@ -104,14 +105,13 @@ export function isDiagnosticFixable(diagnostic: Diagnostic): boolean {
 }
 
 /**
- * Create a code action for a fixable diagnostic.
- * Note: PHPCBF operates on the entire file, so this will fix all auto-fixable
- * issues in the file, not just the specific diagnostic.
+ * Create a code action for a fixable diagnostic that fixes only this specific issue.
+ * Uses diff analysis to apply only the hunk(s) relevant to this diagnostic.
  * @param document The text document
  * @param diagnostic The diagnostic to fix
- * @returns A code action for fixing the issue, or null if not fixable
+ * @returns A code action for fixing only this issue, or null if not fixable
  */
-export function createFixSingleIssueAction(
+export function createFixOnlyThisIssueAction(
 	document: TextDocument,
 	diagnostic: Diagnostic
 ): CodeAction | null {
@@ -120,14 +120,14 @@ export function createFixSingleIssueAction(
 	}
 
 	const action: CodeAction = {
-		title: 'Fix this and other auto-fixable issues (PHPCBF)',
+		title: 'Fix only this issue (PHPCBF)',
 		kind: CodeActionKind.QuickFix,
 		diagnostics: [diagnostic],
 		isPreferred: false,
 		command: {
-			title: 'Fix file with PHPCBF',
-			command: PHPCBF_FIX_FILE_COMMAND,
-			arguments: [document.uri],
+			title: 'Fix single issue with PHPCBF',
+			command: PHPCBF_FIX_SINGLE_COMMAND,
+			arguments: [document.uri, diagnostic],
 		},
 	};
 
@@ -161,11 +161,11 @@ export function generateCodeActions(
 		return actions;
 	}
 
-	// Add "Fix this issue" for each fixable diagnostic in context
+	// Add "Fix only this issue" for each fixable diagnostic in context
 	for (const diagnostic of phpcsInContext) {
-		const singleAction = createFixSingleIssueAction(document, diagnostic);
-		if (singleAction) {
-			actions.push(singleAction);
+		const onlyThisAction = createFixOnlyThisIssueAction(document, diagnostic);
+		if (onlyThisAction) {
+			actions.push(onlyThisAction);
 		}
 	}
 

--- a/phpcs-server/src/code-actions.ts
+++ b/phpcs-server/src/code-actions.ts
@@ -20,6 +20,14 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 export const PHPCBF_FIX_FILE_COMMAND = 'phpcs.fixFile';
 
 /**
+ * Data stored in a PHPCS diagnostic.
+ */
+export interface PhpcsDiagnosticData {
+	fixable: boolean;
+	source?: string;
+}
+
+/**
  * Check if a document has any PHPCS diagnostics.
  * @param diagnostics The diagnostics for the document
  * @returns True if there are PHPCS diagnostics
@@ -86,6 +94,46 @@ export function createFullDocumentEdit(
 }
 
 /**
+ * Check if a diagnostic is marked as fixable.
+ * @param diagnostic The diagnostic to check
+ * @returns True if the diagnostic is fixable
+ */
+export function isDiagnosticFixable(diagnostic: Diagnostic): boolean {
+	const data = diagnostic.data as PhpcsDiagnosticData | undefined;
+	return data?.fixable === true;
+}
+
+/**
+ * Create a "Fix this issue" code action for a fixable diagnostic.
+ * Note: PHPCBF will fix all issues in the file, not just this one.
+ * @param document The text document
+ * @param diagnostic The diagnostic to fix
+ * @returns A code action for fixing the issue, or null if not fixable
+ */
+export function createFixSingleIssueAction(
+	document: TextDocument,
+	diagnostic: Diagnostic
+): CodeAction | null {
+	if (!isDiagnosticFixable(diagnostic)) {
+		return null;
+	}
+
+	const action: CodeAction = {
+		title: 'Fix this issue (PHPCBF)',
+		kind: CodeActionKind.QuickFix,
+		diagnostics: [diagnostic],
+		isPreferred: false,
+		command: {
+			title: 'Fix with PHPCBF',
+			command: PHPCBF_FIX_FILE_COMMAND,
+			arguments: [document.uri],
+		},
+	};
+
+	return action;
+}
+
+/**
  * Generate code actions for a code action request.
  * @param params The code action parameters
  * @param document The text document
@@ -106,14 +154,24 @@ export function generateCodeActions(
 
 	// Check if any diagnostics in the requested range are from PHPCS
 	const contextDiagnostics = params.context.diagnostics || [];
-	const hasPhpcsInRange = hasPhpcsDiagnostics(contextDiagnostics);
+	const phpcsInContext = getPhpcsDiagnostics(contextDiagnostics);
 
-	// If the user clicked on a PHPCS diagnostic, offer to fix all issues
-	if (hasPhpcsInRange) {
-		const fixAllAction = createFixAllInFileAction(document, documentDiagnostics);
-		if (fixAllAction) {
-			actions.push(fixAllAction);
+	if (phpcsInContext.length === 0) {
+		return actions;
+	}
+
+	// Add "Fix this issue" for each fixable diagnostic in context
+	for (const diagnostic of phpcsInContext) {
+		const singleAction = createFixSingleIssueAction(document, diagnostic);
+		if (singleAction) {
+			actions.push(singleAction);
 		}
+	}
+
+	// Add "Fix all issues in file" action
+	const fixAllAction = createFixAllInFileAction(document, documentDiagnostics);
+	if (fixAllAction) {
+		actions.push(fixAllAction);
 	}
 
 	return actions;

--- a/phpcs-server/src/code-actions.ts
+++ b/phpcs-server/src/code-actions.ts
@@ -19,6 +19,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
  */
 export const PHPCBF_FIX_FILE_COMMAND = 'phpcs.fixFile';
 export const PHPCBF_FIX_SINGLE_COMMAND = 'phpcs.fixSingleIssue';
+export const PHPCBF_PREVIEW_COMMAND = 'phpcs.previewFixes';
 
 /**
  * Data stored in a PHPCS diagnostic.
@@ -135,6 +136,36 @@ export function createFixOnlyThisIssueAction(
 }
 
 /**
+ * Create a "Preview fixes" code action that shows a diff preview.
+ * @param document The text document
+ * @param diagnostics The diagnostics in the document
+ * @returns A code action for previewing fixes, or null if no PHPCS diagnostics
+ */
+export function createPreviewFixesAction(
+	document: TextDocument,
+	diagnostics: Diagnostic[]
+): CodeAction | null {
+	const phpcsDiagnostics = getPhpcsDiagnostics(diagnostics);
+
+	if (phpcsDiagnostics.length === 0) {
+		return null;
+	}
+
+	const action: CodeAction = {
+		title: 'Preview fixes (PHPCBF)',
+		kind: CodeActionKind.QuickFix,
+		diagnostics: phpcsDiagnostics,
+		command: {
+			title: 'Preview PHPCBF fixes',
+			command: PHPCBF_PREVIEW_COMMAND,
+			arguments: [document.uri],
+		},
+	};
+
+	return action;
+}
+
+/**
  * Generate code actions for a code action request.
  * @param params The code action parameters
  * @param document The text document
@@ -173,6 +204,12 @@ export function generateCodeActions(
 	const fixAllAction = createFixAllInFileAction(document, documentDiagnostics);
 	if (fixAllAction) {
 		actions.push(fixAllAction);
+	}
+
+	// Add "Preview fixes" action
+	const previewAction = createPreviewFixesAction(document, documentDiagnostics);
+	if (previewAction) {
+		actions.push(previewAction);
 	}
 
 	return actions;

--- a/phpcs-server/src/diff-utils.ts
+++ b/phpcs-server/src/diff-utils.ts
@@ -180,6 +180,10 @@ function groupIntoHunks(ops: LineOp[]): DiffHunk[] {
  * Compute diff hunks between original and modified content.
  * Groups consecutive changes into contiguous hunks.
  *
+ * Note: Empty content is treated as a single empty line (length 1), not zero lines.
+ * This matches JavaScript's `''.split('\n')` behavior which returns `['']`.
+ * This is intentional as it allows proper diffing between empty and non-empty content.
+ *
  * @param original Original content string
  * @param modified Modified content string
  * @returns Array of diff hunks representing changes

--- a/phpcs-server/src/diff-utils.ts
+++ b/phpcs-server/src/diff-utils.ts
@@ -1,0 +1,218 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) John R. D'Orazio. All rights reserved.
+ * Licensed under the MIT License. See License.md in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+/**
+ * Represents a contiguous change region (hunk) in a diff.
+ */
+export interface DiffHunk {
+	/** 0-indexed line number where this hunk starts in the original content */
+	originalStart: number;
+	/** Number of lines removed from original */
+	originalLength: number;
+	/** 0-indexed line number where this hunk starts in the modified content */
+	modifiedStart: number;
+	/** Number of lines added in modified */
+	modifiedLength: number;
+	/** Lines removed from original */
+	originalLines: string[];
+	/** Lines added in modified */
+	modifiedLines: string[];
+}
+
+/**
+ * Internal representation of a single line change used during diff computation.
+ */
+interface LineOp {
+	type: 'equal' | 'delete' | 'insert';
+	originalIndex: number;
+	modifiedIndex: number;
+	line: string;
+}
+
+/**
+ * Compute Longest Common Subsequence of two line arrays.
+ * @param a First array of lines
+ * @param b Second array of lines
+ * @returns Array of common lines in order
+ */
+function computeLCS(a: string[], b: string[]): string[] {
+	const m = a.length;
+	const n = b.length;
+
+	// Build LCS length table
+	const dp: number[][] = Array(m + 1).fill(null).map(() => Array(n + 1).fill(0));
+
+	for (let i = 1; i <= m; i++) {
+		for (let j = 1; j <= n; j++) {
+			if (a[i - 1] === b[j - 1]) {
+				dp[i][j] = dp[i - 1][j - 1] + 1;
+			} else {
+				dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+			}
+		}
+	}
+
+	// Backtrack to find LCS
+	const lcs: string[] = [];
+	let i = m, j = n;
+	while (i > 0 && j > 0) {
+		if (a[i - 1] === b[j - 1]) {
+			lcs.unshift(a[i - 1]);
+			i--;
+			j--;
+		} else if (dp[i - 1][j] > dp[i][j - 1]) {
+			i--;
+		} else {
+			j--;
+		}
+	}
+
+	return lcs;
+}
+
+/**
+ * Compute line-by-line operations between original and modified content.
+ * @param originalLines Lines from original content
+ * @param modifiedLines Lines from modified content
+ * @returns Array of line operations
+ */
+function computeLineOps(originalLines: string[], modifiedLines: string[]): LineOp[] {
+	const lcs = computeLCS(originalLines, modifiedLines);
+	const ops: LineOp[] = [];
+
+	let origIdx = 0;
+	let modIdx = 0;
+	let lcsIdx = 0;
+
+	while (origIdx < originalLines.length || modIdx < modifiedLines.length) {
+		if (lcsIdx < lcs.length &&
+			origIdx < originalLines.length &&
+			modIdx < modifiedLines.length &&
+			originalLines[origIdx] === lcs[lcsIdx] &&
+			modifiedLines[modIdx] === lcs[lcsIdx]) {
+			// Lines match - equal
+			ops.push({
+				type: 'equal',
+				originalIndex: origIdx,
+				modifiedIndex: modIdx,
+				line: originalLines[origIdx]
+			});
+			origIdx++;
+			modIdx++;
+			lcsIdx++;
+		} else if (modIdx < modifiedLines.length &&
+				   (lcsIdx >= lcs.length || modifiedLines[modIdx] !== lcs[lcsIdx])) {
+			// Line added in modified
+			ops.push({
+				type: 'insert',
+				originalIndex: origIdx,
+				modifiedIndex: modIdx,
+				line: modifiedLines[modIdx]
+			});
+			modIdx++;
+		} else if (origIdx < originalLines.length &&
+				   (lcsIdx >= lcs.length || originalLines[origIdx] !== lcs[lcsIdx])) {
+			// Line deleted from original
+			ops.push({
+				type: 'delete',
+				originalIndex: origIdx,
+				modifiedIndex: modIdx,
+				line: originalLines[origIdx]
+			});
+			origIdx++;
+		}
+	}
+
+	return ops;
+}
+
+/**
+ * Group consecutive non-equal operations into hunks.
+ * @param ops Array of line operations
+ * @returns Array of diff hunks
+ */
+function groupIntoHunks(ops: LineOp[]): DiffHunk[] {
+	const hunks: DiffHunk[] = [];
+	let currentHunk: DiffHunk | null = null;
+
+	for (const op of ops) {
+		if (op.type === 'equal') {
+			// End current hunk if any
+			if (currentHunk) {
+				hunks.push(currentHunk);
+				currentHunk = null;
+			}
+		} else {
+			// Start new hunk if needed
+			if (!currentHunk) {
+				currentHunk = {
+					originalStart: op.originalIndex,
+					originalLength: 0,
+					modifiedStart: op.modifiedIndex,
+					modifiedLength: 0,
+					originalLines: [],
+					modifiedLines: []
+				};
+			}
+
+			if (op.type === 'delete') {
+				currentHunk.originalLines.push(op.line);
+				currentHunk.originalLength++;
+			} else if (op.type === 'insert') {
+				currentHunk.modifiedLines.push(op.line);
+				currentHunk.modifiedLength++;
+			}
+		}
+	}
+
+	// Don't forget the last hunk
+	if (currentHunk) {
+		hunks.push(currentHunk);
+	}
+
+	return hunks;
+}
+
+/**
+ * Compute diff hunks between original and modified content.
+ * Groups consecutive changes into contiguous hunks.
+ *
+ * @param original Original content string
+ * @param modified Modified content string
+ * @returns Array of diff hunks representing changes
+ */
+export function computeDiffHunks(original: string, modified: string): DiffHunk[] {
+	const originalLines = original.split('\n');
+	const modifiedLines = modified.split('\n');
+
+	const ops = computeLineOps(originalLines, modifiedLines);
+	return groupIntoHunks(ops);
+}
+
+/**
+ * Check if a line number falls within a hunk's affected range in the original content.
+ * @param hunk The diff hunk
+ * @param lineNumber 0-indexed line number to check
+ * @returns True if the line is within the hunk's original range
+ */
+export function isLineInHunkRange(hunk: DiffHunk, lineNumber: number): boolean {
+	// For pure insertions (originalLength === 0), the line must be at the insertion point
+	if (hunk.originalLength === 0) {
+		return lineNumber === hunk.originalStart;
+	}
+	// For deletions or modifications, check if line is in the affected range
+	return lineNumber >= hunk.originalStart &&
+		   lineNumber < hunk.originalStart + hunk.originalLength;
+}
+
+/**
+ * Get the end line (exclusive) of a hunk in the original content.
+ * @param hunk The diff hunk
+ * @returns The line number after the last affected line
+ */
+export function getHunkOriginalEnd(hunk: DiffHunk): number {
+	return hunk.originalStart + Math.max(hunk.originalLength, 1);
+}

--- a/phpcs-server/src/hunk-correlation.ts
+++ b/phpcs-server/src/hunk-correlation.ts
@@ -1,0 +1,186 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) John R. D'Orazio. All rights reserved.
+ * Licensed under the MIT License. See License.md in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+import { Diagnostic } from 'vscode-languageserver/node';
+import { DiffHunk, isLineInHunkRange } from './diff-utils';
+
+/**
+ * Confidence level for a hunk-to-diagnostic correlation.
+ * - high: Single diagnostic maps to the hunk
+ * - medium: Multiple diagnostics map to the same hunk
+ * - low: Hunk has no matching diagnostics (side-effect of another fix)
+ */
+export type CorrelationConfidence = 'high' | 'medium' | 'low';
+
+/**
+ * Represents a correlation between a diff hunk and the diagnostics it likely fixes.
+ */
+export interface HunkCorrelation {
+	/** The diff hunk */
+	hunk: DiffHunk;
+	/** Diagnostics whose line falls within this hunk's range */
+	diagnostics: Diagnostic[];
+	/** Confidence level of the correlation */
+	confidence: CorrelationConfidence;
+}
+
+/**
+ * Check if a diagnostic is likely fixed by a hunk based on line number.
+ * For pure insertions (like adding blank lines), we also check if the diagnostic
+ * is on the line immediately before or after the insertion point.
+ * @param hunk The diff hunk
+ * @param diagnostic The diagnostic to check
+ * @returns True if the diagnostic's line falls within or is adjacent to the hunk's range
+ */
+export function isDiagnosticInHunk(hunk: DiffHunk, diagnostic: Diagnostic): boolean {
+	// Diagnostics use 0-indexed line numbers
+	const diagnosticLine = diagnostic.range.start.line;
+
+	// For regular hunks (with deletions/modifications), use standard range check
+	if (hunk.originalLength > 0) {
+		return isLineInHunkRange(hunk, diagnosticLine);
+	}
+
+	// For pure insertions (originalLength === 0):
+	// The diagnostic might be on the line before or at the insertion point.
+	// E.g., "missing blank line" at line 9 -> insertion at line 10
+	// Or "missing opening tag" at line 0 -> insertion at line 0
+	const insertionPoint = hunk.originalStart;
+	return diagnosticLine === insertionPoint || diagnosticLine === insertionPoint - 1;
+}
+
+/**
+ * Correlate diagnostics to diff hunks.
+ * Maps each hunk to the diagnostics that fall within its line range.
+ *
+ * @param hunks Array of diff hunks
+ * @param diagnostics Array of diagnostics from PHPCS
+ * @returns Array of hunk correlations with confidence levels
+ */
+export function correlateDiagnosticsToHunks(
+	hunks: DiffHunk[],
+	diagnostics: Diagnostic[]
+): HunkCorrelation[] {
+	const correlations: HunkCorrelation[] = [];
+
+	for (const hunk of hunks) {
+		const matchingDiagnostics = diagnostics.filter(d => isDiagnosticInHunk(hunk, d));
+
+		let confidence: CorrelationConfidence;
+		if (matchingDiagnostics.length === 0) {
+			confidence = 'low';
+		} else if (matchingDiagnostics.length === 1) {
+			confidence = 'high';
+		} else {
+			confidence = 'medium';
+		}
+
+		correlations.push({
+			hunk,
+			diagnostics: matchingDiagnostics,
+			confidence
+		});
+	}
+
+	return correlations;
+}
+
+/**
+ * Find hunks that are correlated with a specific diagnostic.
+ *
+ * @param correlations Array of hunk correlations
+ * @param diagnostic The diagnostic to find hunks for
+ * @returns Array of hunks that contain the diagnostic in their range
+ */
+export function findHunksForDiagnostic(
+	correlations: HunkCorrelation[],
+	diagnostic: Diagnostic
+): DiffHunk[] {
+	const result: DiffHunk[] = [];
+
+	for (const correlation of correlations) {
+		// Check if this correlation contains the target diagnostic
+		const containsDiagnostic = correlation.diagnostics.some(
+			d => diagnosticsMatch(d, diagnostic)
+		);
+		if (containsDiagnostic) {
+			result.push(correlation.hunk);
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Check if two diagnostics match (same location and message).
+ * @param a First diagnostic
+ * @param b Second diagnostic
+ * @returns True if diagnostics match
+ */
+function diagnosticsMatch(a: Diagnostic, b: Diagnostic): boolean {
+	return (
+		a.range.start.line === b.range.start.line &&
+		a.range.start.character === b.range.start.character &&
+		a.range.end.line === b.range.end.line &&
+		a.range.end.character === b.range.end.character &&
+		a.message === b.message
+	);
+}
+
+/**
+ * Get all diagnostics that will be affected by applying a set of hunks.
+ * Useful for showing users which issues will be fixed together.
+ *
+ * @param correlations Array of hunk correlations
+ * @param hunksToApply Hunks that will be applied
+ * @returns All diagnostics that will be fixed by these hunks
+ */
+export function getDiagnosticsForHunks(
+	correlations: HunkCorrelation[],
+	hunksToApply: DiffHunk[]
+): Diagnostic[] {
+	const result: Diagnostic[] = [];
+	const seen = new Set<string>();
+
+	for (const correlation of correlations) {
+		const hunkMatches = hunksToApply.some(h =>
+			h.originalStart === correlation.hunk.originalStart &&
+			h.originalLength === correlation.hunk.originalLength
+		);
+
+		if (hunkMatches) {
+			for (const diagnostic of correlation.diagnostics) {
+				// Create unique key to avoid duplicates
+				const key = `${diagnostic.range.start.line}:${diagnostic.range.start.character}:${diagnostic.message}`;
+				if (!seen.has(key)) {
+					seen.add(key);
+					result.push(diagnostic);
+				}
+			}
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Check if applying a hunk might affect other unrelated lines.
+ * This is useful for detecting potential interdependent fixes.
+ *
+ * @param hunk The hunk to check
+ * @param allCorrelations All correlations in the document
+ * @returns True if the hunk has low confidence (no matching diagnostics)
+ */
+export function isHunkASideEffect(
+	hunk: DiffHunk,
+	allCorrelations: HunkCorrelation[]
+): boolean {
+	const correlation = allCorrelations.find(
+		c => c.hunk.originalStart === hunk.originalStart &&
+			 c.hunk.originalLength === hunk.originalLength
+	);
+	return correlation?.confidence === 'low';
+}

--- a/phpcs-server/src/hunk-correlation.ts
+++ b/phpcs-server/src/hunk-correlation.ts
@@ -28,28 +28,74 @@ export interface HunkCorrelation {
 }
 
 /**
+ * Maximum number of lines between a diagnostic and a pure deletion hunk
+ * for them to be considered related. Kept small to avoid false matches.
+ */
+const MAX_DELETION_PROXIMITY = 2;
+
+/**
+ * Maximum number of lines for header-related fixes (diagnostic at line 0).
+ * Only matches hunks very close to the start of the file.
+ */
+const MAX_HEADER_PROXIMITY = 3;
+
+/**
  * Check if a diagnostic is likely fixed by a hunk based on line number.
- * For pure insertions (like adding blank lines), we also check if the diagnostic
- * is on the line immediately before or after the insertion point.
+ * Handles several cases:
+ * - Standard: diagnostic line falls within hunk's deletion range
+ * - Pure insertions: diagnostic is at or before the insertion point
+ * - Pure deletions (lenient only): diagnostic is near (within proximity) of the deletion
+ * - Header fixes (lenient only): diagnostic at line 0 correlates with nearby hunk
+ *
  * @param hunk The diff hunk
  * @param diagnostic The diagnostic to check
- * @returns True if the diagnostic's line falls within or is adjacent to the hunk's range
+ * @param strict If true, only use direct line matching (for single-issue fixes)
+ * @returns True if the diagnostic is likely fixed by this hunk
  */
-export function isDiagnosticInHunk(hunk: DiffHunk, diagnostic: Diagnostic): boolean {
+export function isDiagnosticInHunk(hunk: DiffHunk, diagnostic: Diagnostic, strict: boolean = false): boolean {
 	// Diagnostics use 0-indexed line numbers
 	const diagnosticLine = diagnostic.range.start.line;
 
-	// For regular hunks (with deletions/modifications), use standard range check
-	if (hunk.originalLength > 0) {
-		return isLineInHunkRange(hunk, diagnosticLine);
+	// Standard case: diagnostic falls within hunk's deletion range
+	if (hunk.originalLength > 0 && isLineInHunkRange(hunk, diagnosticLine)) {
+		return true;
 	}
 
 	// For pure insertions (originalLength === 0):
 	// The diagnostic might be on the line before or at the insertion point.
 	// E.g., "missing blank line" at line 9 -> insertion at line 10
-	// Or "missing opening tag" at line 0 -> insertion at line 0
-	const insertionPoint = hunk.originalStart;
-	return diagnosticLine === insertionPoint || diagnosticLine === insertionPoint - 1;
+	if (hunk.originalLength === 0) {
+		const insertionPoint = hunk.originalStart;
+		if (diagnosticLine === insertionPoint || diagnosticLine === insertionPoint - 1) {
+			return true;
+		}
+	}
+
+	// In strict mode, don't use proximity-based matching
+	// This prevents single-issue fixes from matching unrelated hunks
+	if (strict) {
+		return false;
+	}
+
+	// For pure deletions (removing blank lines) or spacing fixes:
+	// PHPCS often reports errors at block starts but the fix is applied
+	// to a nearby blank line. Only match if diagnostic is very close.
+	if (hunk.modifiedLength === 0 && hunk.originalLength > 0) {
+		// Pure deletion - check if diagnostic is immediately before the hunk
+		const hunkStart = hunk.originalStart;
+		const linesBefore = hunkStart - diagnosticLine;
+		if (linesBefore >= 0 && linesBefore <= MAX_DELETION_PROXIMITY) {
+			return true;
+		}
+	}
+
+	// Header-related fixes: diagnostic at line 0 correlates with
+	// fixes at the very start of the file only
+	if (diagnosticLine === 0 && hunk.originalStart <= MAX_HEADER_PROXIMITY) {
+		return true;
+	}
+
+	return false;
 }
 
 /**
@@ -90,44 +136,31 @@ export function correlateDiagnosticsToHunks(
 
 /**
  * Find hunks that are correlated with a specific diagnostic.
+ * Uses strict matching by default to only return hunks directly related to the diagnostic.
  *
  * @param correlations Array of hunk correlations
  * @param diagnostic The diagnostic to find hunks for
+ * @param useStrictMatching If true (default), use strict matching to avoid false positives
  * @returns Array of hunks that contain the diagnostic in their range
  */
 export function findHunksForDiagnostic(
 	correlations: HunkCorrelation[],
-	diagnostic: Diagnostic
+	diagnostic: Diagnostic,
+	useStrictMatching: boolean = true
 ): DiffHunk[] {
 	const result: DiffHunk[] = [];
 
 	for (const correlation of correlations) {
-		// Check if this correlation contains the target diagnostic
-		const containsDiagnostic = correlation.diagnostics.some(
-			d => diagnosticsMatch(d, diagnostic)
-		);
+		// Always use isDiagnosticInHunk directly for accurate matching
+		// Don't rely on pre-computed correlations which may be too broad
+		const containsDiagnostic = isDiagnosticInHunk(correlation.hunk, diagnostic, useStrictMatching);
+
 		if (containsDiagnostic) {
 			result.push(correlation.hunk);
 		}
 	}
 
 	return result;
-}
-
-/**
- * Check if two diagnostics match (same location and message).
- * @param a First diagnostic
- * @param b Second diagnostic
- * @returns True if diagnostics match
- */
-function diagnosticsMatch(a: Diagnostic, b: Diagnostic): boolean {
-	return (
-		a.range.start.line === b.range.start.line &&
-		a.range.start.character === b.range.start.character &&
-		a.range.end.line === b.range.end.line &&
-		a.range.end.character === b.range.end.character &&
-		a.message === b.message
-	);
 }
 
 /**

--- a/phpcs-server/src/linter-utils.ts
+++ b/phpcs-server/src/linter-utils.ts
@@ -323,7 +323,15 @@ export function createDiagnosticFromMessage(
 		? DiagnosticSeverity.Warning
 		: DiagnosticSeverity.Error;
 
-	return Diagnostic.create(range, diagnosticMessage, severity, undefined, 'phpcs');
+	const diagnostic = Diagnostic.create(range, diagnosticMessage, severity, undefined, 'phpcs');
+
+	// Store fixable flag and source in data property for use by code actions
+	diagnostic.data = {
+		fixable: message.fixable,
+		source: message.source,
+	};
+
+	return diagnostic;
 }
 
 /**

--- a/phpcs-server/src/protocol.ts
+++ b/phpcs-server/src/protocol.ts
@@ -6,6 +6,7 @@
 
 import {
 	NotificationType,
+	RequestType,
 	TextDocumentIdentifier
 } from "vscode-languageserver/node";
 
@@ -51,4 +52,74 @@ export interface DidEndValidateTextDocumentParams {
  */
 export namespace DidEndValidateTextDocumentNotification {
 	export const type = new NotificationType<DidEndValidateTextDocumentParams>("textDocument/didEndValidate");
+}
+
+/**
+ * The parameters sent in a did start fix text document notification
+ */
+export interface DidStartFixTextDocumentParams {
+	/**
+	 * The document on which fixing started.
+	 */
+	textDocument: TextDocumentIdentifier;
+}
+
+/**
+ * The document start fix notification is sent from the server to the client to signal
+ * the start of PHPCBF fixing on a text document.
+ */
+export namespace DidStartFixTextDocumentNotification {
+	export const type = new NotificationType<DidStartFixTextDocumentParams>("textDocument/didStartFix");
+}
+
+/**
+ * The parameters sent in a did end fix text document notification
+ */
+export interface DidEndFixTextDocumentParams {
+	/**
+	 * The document on which fixing ended.
+	 */
+	textDocument: TextDocumentIdentifier;
+	/**
+	 * Whether the document was successfully fixed.
+	 */
+	fixed: boolean;
+	/**
+	 * Error message if fixing failed.
+	 */
+	error?: string;
+}
+
+/**
+ * The document end fix notification is sent from the server to the client to signal
+ * the end of PHPCBF fixing on a text document.
+ */
+export namespace DidEndFixTextDocumentNotification {
+	export const type = new NotificationType<DidEndFixTextDocumentParams>("textDocument/didEndFix");
+}
+
+/**
+ * The parameters for the show diff preview request.
+ */
+export interface ShowDiffPreviewParams {
+	/**
+	 * The document URI.
+	 */
+	uri: string;
+	/**
+	 * The original content before fixes.
+	 */
+	originalContent: string;
+	/**
+	 * The fixed content after PHPCBF.
+	 */
+	fixedContent: string;
+}
+
+/**
+ * Request sent from the server to the client to show a diff preview.
+ * The client should display the diff and return true if the user accepts the changes.
+ */
+export namespace ShowDiffPreviewRequest {
+	export const type = new RequestType<ShowDiffPreviewParams, boolean, void>("phpcs/showDiffPreview");
 }

--- a/phpcs-server/src/protocol.ts
+++ b/phpcs-server/src/protocol.ts
@@ -114,6 +114,12 @@ export interface ShowDiffPreviewParams {
 	 * The fixed content after PHPCBF.
 	 */
 	fixedContent: string;
+	/**
+	 * Optional target line for positioning the CodeLens (0-indexed).
+	 * If provided, the accept/reject CodeLens will be positioned near this line.
+	 * If not provided, it will be at the top of the file.
+	 */
+	targetLine?: number;
 }
 
 /**
@@ -122,4 +128,22 @@ export interface ShowDiffPreviewParams {
  */
 export namespace ShowDiffPreviewRequest {
 	export const type = new RequestType<ShowDiffPreviewParams, boolean, void>("phpcs/showDiffPreview");
+}
+
+/**
+ * The parameters for the save document notification.
+ */
+export interface SaveDocumentParams {
+	/**
+	 * The document URI to save.
+	 */
+	uri: string;
+}
+
+/**
+ * Notification sent from the server to the client to request saving a document.
+ * The client should save the document if the phpcbfSaveOnFix setting is enabled.
+ */
+export namespace SaveDocumentNotification {
+	export const type = new NotificationType<SaveDocumentParams>("phpcs/saveDocument");
 }

--- a/phpcs-server/src/protocol.ts
+++ b/phpcs-server/src/protocol.ts
@@ -99,6 +99,36 @@ export namespace DidEndFixTextDocumentNotification {
 }
 
 /**
+ * Represents a diff hunk for preview display.
+ */
+export interface PreviewDiffHunk {
+	/**
+	 * 0-indexed starting line in the original file.
+	 */
+	originalStart: number;
+	/**
+	 * Number of lines removed from the original.
+	 */
+	originalLength: number;
+	/**
+	 * 0-indexed starting line in the modified file.
+	 */
+	modifiedStart: number;
+	/**
+	 * Number of lines added in the modified file.
+	 */
+	modifiedLength: number;
+	/**
+	 * The original lines being removed.
+	 */
+	originalLines: string[];
+	/**
+	 * The new lines being added.
+	 */
+	modifiedLines: string[];
+}
+
+/**
  * The parameters for the show diff preview request.
  */
 export interface ShowDiffPreviewParams {
@@ -120,6 +150,11 @@ export interface ShowDiffPreviewParams {
 	 * If not provided, it will be at the top of the file.
 	 */
 	targetLine?: number;
+	/**
+	 * The diff hunks representing individual changes.
+	 * Each hunk can be accepted or rejected individually.
+	 */
+	hunks?: PreviewDiffHunk[];
 }
 
 /**

--- a/phpcs-server/src/selective-fix.ts
+++ b/phpcs-server/src/selective-fix.ts
@@ -1,0 +1,181 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) John R. D'Orazio. All rights reserved.
+ * Licensed under the MIT License. See License.md in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+import { DiffHunk } from './diff-utils';
+
+/**
+ * Sort hunks by their original start line in descending order.
+ * This is crucial for applying hunks from bottom to top to avoid line number shifting.
+ *
+ * @param hunks Array of hunks to sort
+ * @returns New sorted array (does not modify original)
+ */
+export function sortHunksDescending(hunks: DiffHunk[]): DiffHunk[] {
+	return [...hunks].sort((a, b) => b.originalStart - a.originalStart);
+}
+
+/**
+ * Apply selected hunks to the original content.
+ * Hunks are applied from bottom to top to prevent line number shifting issues.
+ *
+ * @param originalContent The original file content
+ * @param hunks Array of hunks to apply
+ * @returns The content with selected hunks applied
+ */
+export function applyHunks(originalContent: string, hunks: DiffHunk[]): string {
+	if (hunks.length === 0) {
+		return originalContent;
+	}
+
+	const lines = originalContent.split('\n');
+
+	// Sort hunks descending by original start line
+	// This ensures we apply from bottom to top, avoiding line number shifts
+	const sortedHunks = sortHunksDescending(hunks);
+
+	for (const hunk of sortedHunks) {
+		// Replace the original lines with the modified lines
+		// splice(start, deleteCount, ...items)
+		lines.splice(
+			hunk.originalStart,
+			hunk.originalLength,
+			...hunk.modifiedLines
+		);
+	}
+
+	return lines.join('\n');
+}
+
+/**
+ * Check if two hunks overlap in the original content.
+ * Overlapping hunks cannot be applied independently.
+ *
+ * @param a First hunk
+ * @param b Second hunk
+ * @returns True if hunks overlap
+ */
+export function hunksOverlap(a: DiffHunk, b: DiffHunk): boolean {
+	const aEnd = a.originalStart + a.originalLength;
+	const bEnd = b.originalStart + b.originalLength;
+
+	// Handle pure insertions (length 0)
+	if (a.originalLength === 0 && b.originalLength === 0) {
+		// Two insertions at the same point overlap
+		return a.originalStart === b.originalStart;
+	}
+
+	if (a.originalLength === 0) {
+		// a is pure insertion, check if it's within b's range
+		return a.originalStart >= b.originalStart && a.originalStart < bEnd;
+	}
+
+	if (b.originalLength === 0) {
+		// b is pure insertion, check if it's within a's range
+		return b.originalStart >= a.originalStart && b.originalStart < aEnd;
+	}
+
+	// Standard overlap check
+	return !(aEnd <= b.originalStart || bEnd <= a.originalStart);
+}
+
+/**
+ * Check if a set of hunks can be applied independently without conflicts.
+ *
+ * @param hunks Array of hunks to check
+ * @returns True if all hunks are non-overlapping
+ */
+export function areHunksIndependent(hunks: DiffHunk[]): boolean {
+	for (let i = 0; i < hunks.length; i++) {
+		for (let j = i + 1; j < hunks.length; j++) {
+			if (hunksOverlap(hunks[i], hunks[j])) {
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
+/**
+ * Calculate the line offset caused by applying a hunk.
+ * Positive means lines shift down, negative means lines shift up.
+ *
+ * @param hunk The hunk to calculate offset for
+ * @returns The line offset
+ */
+export function calculateLineOffset(hunk: DiffHunk): number {
+	return hunk.modifiedLength - hunk.originalLength;
+}
+
+/**
+ * Calculate the total line offset for a set of hunks.
+ *
+ * @param hunks Array of hunks
+ * @returns Total line offset
+ */
+export function calculateTotalLineOffset(hunks: DiffHunk[]): number {
+	return hunks.reduce((sum, hunk) => sum + calculateLineOffset(hunk), 0);
+}
+
+/**
+ * Validate that hunks can be safely applied.
+ *
+ * @param originalContent The original content
+ * @param hunks Hunks to validate
+ * @returns Object with valid flag and optional error message
+ */
+export function validateHunks(
+	originalContent: string,
+	hunks: DiffHunk[]
+): { valid: boolean; error?: string } {
+	if (hunks.length === 0) {
+		return { valid: true };
+	}
+
+	const lines = originalContent.split('\n');
+	const lineCount = lines.length;
+
+	for (const hunk of hunks) {
+		// Check if hunk start is within bounds
+		if (hunk.originalStart < 0 || hunk.originalStart > lineCount) {
+			return {
+				valid: false,
+				error: `Hunk start ${hunk.originalStart} is out of bounds (0-${lineCount})`
+			};
+		}
+
+		// Check if hunk end is within bounds
+		const hunkEnd = hunk.originalStart + hunk.originalLength;
+		if (hunkEnd > lineCount) {
+			return {
+				valid: false,
+				error: `Hunk end ${hunkEnd} exceeds line count ${lineCount}`
+			};
+		}
+
+		// Verify original lines match (if we have them)
+		if (hunk.originalLines.length > 0 && hunk.originalLength > 0) {
+			for (let i = 0; i < hunk.originalLength; i++) {
+				const lineIndex = hunk.originalStart + i;
+				if (lines[lineIndex] !== hunk.originalLines[i]) {
+					return {
+						valid: false,
+						error: `Line ${lineIndex} content mismatch: expected "${hunk.originalLines[i]}" but found "${lines[lineIndex]}"`
+					};
+				}
+			}
+		}
+	}
+
+	// Check for overlapping hunks
+	if (!areHunksIndependent(hunks)) {
+		return {
+			valid: false,
+			error: 'Hunks overlap and cannot be applied independently'
+		};
+	}
+
+	return { valid: true };
+}

--- a/phpcs-server/src/server.ts
+++ b/phpcs-server/src/server.ts
@@ -625,6 +625,7 @@ class PhpcsServer {
 			const partiallyFixedContent = applyHunks(originalContent, relevantHunks);
 
 			// Apply the fix using workspace edit
+			const versionBeforeEdit = document.version;
 			const edit = createFullDocumentEdit(document, partiallyFixedContent);
 			const applied = await this.connection.workspace.applyEdit({
 				changes: {
@@ -635,6 +636,10 @@ class PhpcsServer {
 			if (applied.applied) {
 				fixed = true;
 				this.connection.console.log(`[PHPCBF] Single issue fix applied to: ${uri}`);
+
+				// Wait for document sync before re-linting
+				// The client applied edits, so we expect version > versionBeforeEdit
+				await this.waitForDocumentChange(uri, versionBeforeEdit + 1);
 
 				// Re-lint the document to refresh diagnostics
 				const updatedDocument = this.documents.get(uri);

--- a/phpcs-server/src/server.ts
+++ b/phpcs-server/src/server.ts
@@ -362,6 +362,20 @@ class PhpcsServer {
 			this.validating.delete(uri);
 		}
 
+		// Clear any pending save acknowledgments (resolve to unblock waiters)
+		const pendingSave = this.pendingSaveAcknowledgments.get(uri);
+		if (pendingSave) {
+			this.pendingSaveAcknowledgments.delete(uri);
+			pendingSave();
+		}
+
+		// Clear any pending document change watchers (resolve to unblock waiters)
+		const pendingChange = this.pendingDocumentChanges.get(uri);
+		if (pendingChange) {
+			this.pendingDocumentChanges.delete(uri);
+			pendingChange.resolve();
+		}
+
 		this.clearDiagnostics(uri);
 	}
 
@@ -1207,6 +1221,12 @@ class PhpcsServer {
 	 */
 	private waitForSaveAcknowledgment(uri: string): Promise<void> {
 		return new Promise((resolve) => {
+			// Resolve any existing pending wait to avoid orphaned promises
+			const existingResolve = this.pendingSaveAcknowledgments.get(uri);
+			if (existingResolve) {
+				existingResolve();
+			}
+
 			// Set up the acknowledgment resolver
 			this.pendingSaveAcknowledgments.set(uri, resolve);
 
@@ -1241,6 +1261,12 @@ class PhpcsServer {
 			if (currentDoc && currentDoc.version >= minVersion) {
 				resolve();
 				return;
+			}
+
+			// Resolve any existing pending wait to avoid orphaned promises
+			const existingPending = this.pendingDocumentChanges.get(uri);
+			if (existingPending) {
+				existingPending.resolve();
 			}
 
 			// Set up the change watcher

--- a/phpcs-server/src/server.ts
+++ b/phpcs-server/src/server.ts
@@ -9,6 +9,7 @@ import * as strings from "./base/common/strings";
 
 import {
 	CodeAction,
+	CodeActionKind,
 	CodeActionParams,
 	createConnection,
 	Diagnostic,
@@ -40,6 +41,7 @@ import {
 	createFullDocumentEdit,
 	PHPCBF_FIX_FILE_COMMAND,
 	PHPCBF_FIX_SINGLE_COMMAND,
+	PHPCBF_PREVIEW_COMMAND,
 } from "./code-actions";
 import { computeDiffHunks } from "./diff-utils";
 import { correlateDiagnosticsToHunks, findHunksForDiagnostic } from "./hunk-correlation";
@@ -163,9 +165,11 @@ class PhpcsServer {
 					willSaveWaitUntil: true,
 					save: { includeText: false },
 				},
-				codeActionProvider: true,
+				codeActionProvider: {
+					codeActionKinds: [CodeActionKind.QuickFix],
+				},
 				executeCommandProvider: {
-					commands: [PHPCBF_FIX_FILE_COMMAND, PHPCBF_FIX_SINGLE_COMMAND],
+					commands: [PHPCBF_FIX_FILE_COMMAND, PHPCBF_FIX_SINGLE_COMMAND, PHPCBF_PREVIEW_COMMAND],
 				},
 			}
 		});
@@ -399,6 +403,18 @@ class PhpcsServer {
 			}
 
 			await this.fixSingleIssue(document, diagnostic);
+		} else if (params.command === PHPCBF_PREVIEW_COMMAND) {
+			const uri = params.arguments?.[0] as string | undefined;
+			if (!uri) {
+				return;
+			}
+
+			const document = this.documents.get(uri);
+			if (!document) {
+				return;
+			}
+
+			await this.previewFixes(document);
 		}
 	}
 
@@ -473,11 +489,16 @@ class PhpcsServer {
 
 		try {
 			this.connection.console.log(strings.format(SR.PhpcbfFixingDocument, uri));
+			this.connection.console.log(`[PHPCBF] Document version: ${document.version}`);
+			this.connection.console.log(`[PHPCBF] Target diagnostic at line ${targetDiagnostic.range.start.line}: "${targetDiagnostic.message}"`);
+
 			const fixer = await PhpcbfFixer.create(phpcbfPath);
 			fixer.setLogger((message) => this.connection.console.log(message));
 
 			// Get the fully fixed content from PHPCBF
 			const result = await fixer.fix(document, settings);
+
+			this.connection.console.log(`[PHPCBF] Fix result: fixed=${result.fixed}, hasUnfixableIssues=${result.hasUnfixableIssues}, error=${result.error || 'none'}`);
 
 			if (result.error) {
 				errorMessage = result.error;
@@ -487,6 +508,9 @@ class PhpcsServer {
 
 			if (!result.fixed) {
 				this.connection.console.log(`[PHPCBF] No fixes available for: ${uri}`);
+				this.connection.window.showInformationMessage(
+					'No fixes available. The issue may have already been fixed or is not auto-fixable.'
+				);
 				return;
 			}
 
@@ -516,9 +540,16 @@ class PhpcsServer {
 				this.connection.console.log(`[PHPCBF]   Correlation: hunk at line ${corr.hunk.originalStart} has ${corr.diagnostics.length} diagnostics (${corr.confidence})`);
 			}
 
-			// Find hunks for the specific diagnostic
-			const relevantHunks = findHunksForDiagnostic(correlations, targetDiagnostic);
-			this.connection.console.log(`[PHPCBF] Found ${relevantHunks.length} relevant hunks for target diagnostic`);
+			// Find hunks for the specific diagnostic using strict matching first
+			let relevantHunks = findHunksForDiagnostic(correlations, targetDiagnostic, true);
+			this.connection.console.log(`[PHPCBF] Found ${relevantHunks.length} relevant hunks with strict matching`);
+
+			// If strict matching found nothing, fall back to lenient matching
+			if (relevantHunks.length === 0) {
+				this.connection.console.log(`[PHPCBF] Trying lenient matching...`);
+				relevantHunks = findHunksForDiagnostic(correlations, targetDiagnostic, false);
+				this.connection.console.log(`[PHPCBF] Found ${relevantHunks.length} relevant hunks with lenient matching`);
+			}
 
 			if (relevantHunks.length === 0) {
 				// No hunk found for this diagnostic - might be a side effect of another fix
@@ -550,24 +581,6 @@ class PhpcsServer {
 			// Apply only the relevant hunks
 			const partiallyFixedContent = applyHunks(originalContent, relevantHunks);
 
-			// Check if diff preview is enabled
-			if (settings.phpcbfShowDiff) {
-				const shouldApply = await this.connection.sendRequest(
-					proto.ShowDiffPreviewRequest.type,
-					{
-						uri,
-						originalContent,
-						fixedContent: partiallyFixedContent,
-						targetLine: targetDiagnostic.range.start.line,
-					}
-				);
-
-				if (!shouldApply) {
-					this.connection.console.log(strings.format(SR.PhpcbfDiffCancelled, uri));
-					return;
-				}
-			}
-
 			// Apply the fix using workspace edit
 			const edit = createFullDocumentEdit(document, partiallyFixedContent);
 			const applied = await this.connection.workspace.applyEdit({
@@ -587,7 +600,9 @@ class PhpcsServer {
 				}
 
 				// Request the client to save the document if setting is enabled
+				this.connection.console.log(`[PHPCBF] phpcbfSaveOnFix setting: ${settings.phpcbfSaveOnFix}`);
 				if (settings.phpcbfSaveOnFix) {
+					this.connection.console.log(`[PHPCBF] Sending SaveDocumentNotification for: ${uri}`);
 					this.connection.sendNotification(proto.SaveDocumentNotification.type, { uri });
 				}
 			} else {
@@ -596,6 +611,185 @@ class PhpcsServer {
 		} catch (error) {
 			errorMessage = error instanceof Error ? error.message : String(error);
 			this.connection.console.error(`[PHPCBF] Error fixing single issue: ${errorMessage}`);
+		} finally {
+			// Send end notification
+			this.connection.sendNotification(
+				proto.DidEndFixTextDocumentNotification.type,
+				{
+					textDocument: TextDocumentIdentifier.create(uri),
+					fixed,
+					error: errorMessage,
+				}
+			);
+		}
+	}
+
+	/**
+	 * Preview PHPCBF fixes with inline diff.
+	 * Always shows the diff preview regardless of settings.
+	 *
+	 * @param document The text document to preview fixes for.
+	 * @return void
+	 */
+	private async previewFixes(document: TextDocument): Promise<void> {
+		const uri = document.uri;
+
+		const settings = await this.getDocumentSettings(document);
+
+		if (!settings.phpcbfEnable) {
+			return;
+		}
+
+		const phpcbfPath = this.resolvePhpcbfPath(settings);
+		if (!phpcbfPath) {
+			this.connection.window.showWarningMessage(
+				'PHPCBF executable not found. Please set phpcs.phpcbfExecutablePath or ensure phpcbf is alongside phpcs.'
+			);
+			return;
+		}
+
+		// Check if a fix is already in progress for this document.
+		if (this.fixingDocuments.has(uri)) {
+			this.connection.console.log(`[PHPCBF] Fix already in progress for: ${uri}, skipping duplicate request`);
+			return;
+		}
+
+		// Create the fix operation promise and track it
+		const fixOperation = this.executePreviewOperation(document, settings, phpcbfPath, uri);
+		this.fixingDocuments.set(uri, fixOperation);
+
+		try {
+			await fixOperation;
+		} finally {
+			// Always clean up the tracking entry when done
+			this.fixingDocuments.delete(uri);
+		}
+	}
+
+	/**
+	 * Execute the preview operation for a document.
+	 * Shows diff preview and applies fixes if user accepts.
+	 *
+	 * @param document The text document to preview.
+	 * @param settings The PHPCS settings.
+	 * @param phpcbfPath Path to the PHPCBF executable.
+	 * @param uri The document URI.
+	 * @return void
+	 */
+	private async executePreviewOperation(
+		_document: TextDocument,
+		settings: PhpcsSettings,
+		phpcbfPath: string,
+		uri: string
+	): Promise<void> {
+		// Send start notification
+		this.connection.sendNotification(
+			proto.DidStartFixTextDocumentNotification.type,
+			{ textDocument: TextDocumentIdentifier.create(uri) }
+		);
+
+		let fixed = false;
+		let errorMessage: string | undefined;
+
+		try {
+			this.connection.console.log(strings.format(SR.PhpcbfFixingDocument, uri));
+			const fixer = await PhpcbfFixer.create(phpcbfPath);
+			fixer.setLogger((message) => this.connection.console.log(message));
+
+			// Loop to handle incremental fixes - after each accepted fix,
+			// re-check for more fixes and show preview again
+			let continueFixing = true;
+			let hasUnfixableIssues = false;
+
+			while (continueFixing) {
+				// Get the latest document content
+				const currentDocument = this.documents.get(uri);
+				if (!currentDocument) {
+					break;
+				}
+
+				const result = await fixer.fix(currentDocument, settings);
+
+				if (result.error) {
+					errorMessage = result.error;
+					this.connection.window.showErrorMessage(strings.format(SR.PhpcbfErrorMessage, result.error));
+					break;
+				}
+
+				if (result.hasUnfixableIssues) {
+					hasUnfixableIssues = true;
+				}
+
+				if (!result.fixed) {
+					// No more fixes available
+					if (!fixed) {
+						this.connection.console.log(strings.format(SR.PhpcbfNoFixesApplied, uri));
+					}
+					break;
+				}
+
+				// Compute hunks for per-change preview
+				const originalContent = currentDocument.getText();
+				const hunks = computeDiffHunks(originalContent, result.content);
+
+				if (hunks.length === 0) {
+					break;
+				}
+
+				// End the "fixing" status before showing interactive preview
+				this.connection.sendNotification(
+					proto.DidEndFixTextDocumentNotification.type,
+					{ textDocument: TextDocumentIdentifier.create(uri), fixed: false }
+				);
+
+				// Show diff preview
+				const shouldApply = await this.connection.sendRequest(
+					proto.ShowDiffPreviewRequest.type,
+					{
+						uri,
+						originalContent,
+						fixedContent: result.content,
+						hunks,
+					}
+				);
+
+				if (!shouldApply) {
+					// User cancelled - stop the loop
+					this.connection.console.log(strings.format(SR.PhpcbfDiffCancelled, uri));
+					continueFixing = false;
+					break;
+				}
+
+				// The client has already applied the selected hunks
+				fixed = true;
+				this.connection.console.log(strings.format(SR.PhpcbfFixApplied, uri));
+
+				// Save after each accepted fix if setting is enabled
+				if (settings.phpcbfSaveOnFix) {
+					this.connection.sendNotification(proto.SaveDocumentNotification.type, { uri });
+					// Wait for save to complete before re-linting
+					await new Promise(resolve => setTimeout(resolve, 100));
+				}
+
+				// Re-lint the document to refresh diagnostics
+				const updatedDocument = this.documents.get(uri);
+				if (updatedDocument) {
+					await this.validateSingle(updatedDocument);
+				}
+
+				// Continue loop to check for more fixes
+				// Small delay to allow document sync
+				await new Promise(resolve => setTimeout(resolve, 100));
+			}
+
+			if (hasUnfixableIssues) {
+				this.connection.window.showInformationMessage(SR.PhpcbfUnfixableIssues);
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			errorMessage = message;
+			this.connection.console.error(strings.format(SR.PhpcbfError, message));
+			this.connection.window.showErrorMessage(strings.format(SR.PhpcbfErrorMessage, message));
 		} finally {
 			// Send end notification
 			this.connection.sendNotification(
@@ -691,23 +885,6 @@ class PhpcsServer {
 			}
 
 			if (result.fixed) {
-				// Check if diff preview is enabled
-				if (settings.phpcbfShowDiff) {
-					const shouldApply = await this.connection.sendRequest(
-						proto.ShowDiffPreviewRequest.type,
-						{
-							uri,
-							originalContent: document.getText(),
-							fixedContent: result.content,
-						}
-					);
-
-					if (!shouldApply) {
-						this.connection.console.log(strings.format(SR.PhpcbfDiffCancelled, uri));
-						return;
-					}
-				}
-
 				// Apply the fix using workspace edit
 				const edit = createFullDocumentEdit(document, result.content);
 				const applied = await this.connection.workspace.applyEdit({
@@ -948,8 +1125,12 @@ class PhpcsServer {
 				: { section: 'phpcs', scopeUri: uri };
 			const settingsPromise = this.connection.workspace.getConfiguration(configurationItem)
 				.then((config: PhpcsSettings | null) => {
+					// Debug: log the raw config received
+					this.connection.console.log(`[PHPCS] Raw config for ${uri}: ${JSON.stringify(config)}`);
 					// Merge with defaults to ensure all properties exist
-					return { ...this.defaultSettings, ...config };
+					const merged = { ...this.defaultSettings, ...config };
+					this.connection.console.log(`[PHPCS] Merged phpcbfSaveOnFix: ${merged.phpcbfSaveOnFix}`);
+					return merged;
 				});
 			this.documentSettings.set(uri, settingsPromise);
 			return settingsPromise;

--- a/phpcs-server/src/server.ts
+++ b/phpcs-server/src/server.ts
@@ -939,6 +939,7 @@ class PhpcsServer {
 
 			if (result.fixed) {
 				// Apply the fix using workspace edit
+				const versionBeforeEdit = document.version;
 				const edit = createFullDocumentEdit(document, result.content);
 				const applied = await this.connection.workspace.applyEdit({
 					changes: {
@@ -950,10 +951,11 @@ class PhpcsServer {
 					fixed = true;
 					this.connection.console.log(strings.format(SR.PhpcbfFixApplied, uri));
 
+					// Wait for document sync before re-linting
+					// The client applied edits, so we expect version > versionBeforeEdit
+					await this.waitForDocumentChange(uri, versionBeforeEdit + 1);
+
 					// Re-lint the document to refresh diagnostics
-					// We need to get the updated document after the edit is applied
-					// The document will be updated via onDidChangeDocument, which triggers validation
-					// But we should also trigger validation explicitly in case lintOnType is disabled
 					const updatedDocument = this.documents.get(uri);
 					if (updatedDocument) {
 						await this.validateSingle(updatedDocument);

--- a/phpcs-server/src/server.ts
+++ b/phpcs-server/src/server.ts
@@ -78,6 +78,7 @@ class PhpcsServer {
 		phpcbfEnable: true,
 		phpcbfExecutablePath: null,
 		phpcbfOnSave: false,
+		phpcbfShowDiff: false,
 		phpcbfTimeout: 60,
 	};
 	private documentSettings: Map<string, Promise<PhpcsSettings>> = new Map();
@@ -444,6 +445,15 @@ class PhpcsServer {
 		phpcbfPath: string,
 		uri: string
 	): Promise<void> {
+		// Send start notification
+		this.connection.sendNotification(
+			proto.DidStartFixTextDocumentNotification.type,
+			{ textDocument: TextDocumentIdentifier.create(uri) }
+		);
+
+		let fixed = false;
+		let errorMessage: string | undefined;
+
 		try {
 			this.connection.console.log(strings.format(SR.PhpcbfFixingDocument, uri));
 			const fixer = await PhpcbfFixer.create(phpcbfPath);
@@ -452,11 +462,29 @@ class PhpcsServer {
 			const result = await fixer.fix(document, settings);
 
 			if (result.error) {
+				errorMessage = result.error;
 				this.connection.window.showErrorMessage(strings.format(SR.PhpcbfErrorMessage, result.error));
 				return;
 			}
 
 			if (result.fixed) {
+				// Check if diff preview is enabled
+				if (settings.phpcbfShowDiff) {
+					const shouldApply = await this.connection.sendRequest(
+						proto.ShowDiffPreviewRequest.type,
+						{
+							uri,
+							originalContent: document.getText(),
+							fixedContent: result.content,
+						}
+					);
+
+					if (!shouldApply) {
+						this.connection.console.log(strings.format(SR.PhpcbfDiffCancelled, uri));
+						return;
+					}
+				}
+
 				// Apply the fix using workspace edit
 				const edit = createFullDocumentEdit(document, result.content);
 				const applied = await this.connection.workspace.applyEdit({
@@ -466,6 +494,7 @@ class PhpcsServer {
 				});
 
 				if (applied.applied) {
+					fixed = true;
 					this.connection.console.log(strings.format(SR.PhpcbfFixApplied, uri));
 
 					// Re-lint the document to refresh diagnostics
@@ -488,8 +517,19 @@ class PhpcsServer {
 			}
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
+			errorMessage = message;
 			this.connection.console.error(strings.format(SR.PhpcbfError, message));
 			this.connection.window.showErrorMessage(strings.format(SR.PhpcbfErrorMessage, message));
+		} finally {
+			// Send end notification
+			this.connection.sendNotification(
+				proto.DidEndFixTextDocumentNotification.type,
+				{
+					textDocument: TextDocumentIdentifier.create(uri),
+					fixed,
+					error: errorMessage,
+				}
+			);
 		}
 	}
 

--- a/phpcs-server/src/server.ts
+++ b/phpcs-server/src/server.ts
@@ -1169,12 +1169,8 @@ class PhpcsServer {
 				: { section: 'phpcs', scopeUri: uri };
 			const settingsPromise = this.connection.workspace.getConfiguration(configurationItem)
 				.then((config: PhpcsSettings | null) => {
-					// Debug: log the raw config received
-					this.connection.console.log(`[PHPCS] Raw config for ${uri}: ${JSON.stringify(config)}`);
 					// Merge with defaults to ensure all properties exist
-					const merged = { ...this.defaultSettings, ...config };
-					this.connection.console.log(`[PHPCS] Merged phpcbfSaveOnFix: ${merged.phpcbfSaveOnFix}`);
-					return merged;
+					return { ...this.defaultSettings, ...config };
 				});
 			this.documentSettings.set(uri, settingsPromise);
 			return settingsPromise;

--- a/phpcs-server/src/server.ts
+++ b/phpcs-server/src/server.ts
@@ -480,9 +480,7 @@ class PhpcsServer {
 
 		const phpcbfPath = this.resolvePhpcbfPath(settings);
 		if (!phpcbfPath) {
-			this.connection.window.showWarningMessage(
-				'PHPCBF executable not found. Please set phpcs.phpcbfExecutablePath or ensure phpcbf is alongside phpcs.'
-			);
+			this.connection.window.showWarningMessage(SR.PhpcbfExecutableNotFound);
 			return;
 		}
 
@@ -551,9 +549,7 @@ class PhpcsServer {
 
 			if (!result.fixed) {
 				this.connection.console.log(`[PHPCBF] No fixes available for: ${uri}`);
-				this.connection.window.showInformationMessage(
-					'No fixes available. The issue may have already been fixed or is not auto-fixable.'
-				);
+				this.connection.window.showInformationMessage(SR.PhpcbfNoFixesAvailable);
 				return;
 			}
 
@@ -607,9 +603,7 @@ class PhpcsServer {
 					this.connection.console.log(`[PHPCBF]   Hunk ${hunk.originalStart}-${hunk.originalStart + hunk.originalLength} covers line ${targetDiagnostic.range.start.line}? ${coversLine}`);
 				}
 
-				this.connection.window.showWarningMessage(
-					'Could not isolate this specific fix. The fix may depend on other changes. Use "Fix all" to apply all fixes.'
-				);
+				this.connection.window.showWarningMessage(SR.PhpcbfCannotIsolateFix);
 				return;
 			}
 
@@ -617,7 +611,7 @@ class PhpcsServer {
 			const validation = validateHunks(originalContent, relevantHunks);
 			if (!validation.valid) {
 				this.connection.console.log(`[PHPCBF] Hunk validation failed: ${validation.error}`);
-				this.connection.window.showErrorMessage(`Cannot apply fix: ${validation.error}`);
+				this.connection.window.showErrorMessage(strings.format(SR.PhpcbfCannotApplyFix, validation.error));
 				return;
 			}
 
@@ -690,9 +684,7 @@ class PhpcsServer {
 
 		const phpcbfPath = this.resolvePhpcbfPath(settings);
 		if (!phpcbfPath) {
-			this.connection.window.showWarningMessage(
-				'PHPCBF executable not found. Please set phpcs.phpcbfExecutablePath or ensure phpcbf is alongside phpcs.'
-			);
+			this.connection.window.showWarningMessage(SR.PhpcbfExecutableNotFound);
 			return;
 		}
 
@@ -869,9 +861,7 @@ class PhpcsServer {
 
 		const phpcbfPath = this.resolvePhpcbfPath(settings);
 		if (!phpcbfPath) {
-			this.connection.window.showWarningMessage(
-				'PHPCBF executable not found. Please set phpcs.phpcbfExecutablePath or ensure phpcbf is alongside phpcs.'
-			);
+			this.connection.window.showWarningMessage(SR.PhpcbfExecutableNotFound);
 			return;
 		}
 

--- a/phpcs-server/src/server.ts
+++ b/phpcs-server/src/server.ts
@@ -85,7 +85,6 @@ class PhpcsServer {
 		phpcbfExecutablePath: null,
 		phpcbfOnSave: false,
 		phpcbfSaveOnFix: false,
-		phpcbfShowDiff: false,
 		phpcbfTimeout: 60,
 	};
 	private documentSettings: Map<string, Promise<PhpcsSettings>> = new Map();

--- a/phpcs-server/src/server.ts
+++ b/phpcs-server/src/server.ts
@@ -47,6 +47,26 @@ import { computeDiffHunks } from "./diff-utils";
 import { correlateDiagnosticsToHunks, findHunksForDiagnostic } from "./hunk-correlation";
 import { applyHunks, validateHunks } from "./selective-fix";
 
+/**
+ * Maximum time in milliseconds to wait for a save acknowledgment before
+ * falling back to a timeout.
+ *
+ * The server uses the LSP didSave notification to detect when saves complete,
+ * but we need a fallback in case the notification is missed or delayed.
+ */
+const SAVE_ACKNOWLEDGMENT_TIMEOUT_MS = 5000;
+
+/**
+ * Maximum time in milliseconds to wait for a document version change before
+ * falling back to a timeout.
+ *
+ * When the client applies edits, it sends a didChange notification with an
+ * incremented version. We wait for this notification to ensure we have the
+ * latest content before proceeding. The timeout is a fallback in case the
+ * notification is missed.
+ */
+const DOCUMENT_CHANGE_TIMEOUT_MS = 5000;
+
 class PhpcsServer {
 	private openedFiles: Map<string, boolean>;
 	private connection: ReturnType<typeof createConnection>;
@@ -56,6 +76,10 @@ class PhpcsServer {
 	private documentDiagnostics: Map<string, Diagnostic[]>;
 	// Track ongoing PHPCBF fix operations to prevent concurrent fixes on the same file
 	private fixingDocuments: Map<string, Promise<void>>;
+	// Track pending save acknowledgments for promise-based save completion
+	private pendingSaveAcknowledgments: Map<string, () => void>;
+	// Track pending document version changes for promise-based sync
+	private pendingDocumentChanges: Map<string, { minVersion: number; resolve: () => void }>;
 
 	// Cache the settings of all open documents
 	private hasConfigurationCapability: boolean = false;
@@ -100,6 +124,8 @@ class PhpcsServer {
 		this.queue = new Map();
 		this.documentDiagnostics = new Map();
 		this.fixingDocuments = new Map();
+		this.pendingSaveAcknowledgments = new Map();
+		this.pendingDocumentChanges = new Map();
 		this.connection = createConnection(ProposedFeatures.all);
 		this.documents = new TextDocuments(TextDocument);
 		this.documents.listen(this.connection);
@@ -299,6 +325,15 @@ class PhpcsServer {
 	 * @return void
 	 */
 	private async onDidSaveDocument({ document }: { document: TextDocument }): Promise<void> {
+		const uri = document.uri;
+
+		// Resolve any pending save acknowledgment for this document
+		const pendingResolve = this.pendingSaveAcknowledgments.get(uri);
+		if (pendingResolve) {
+			this.pendingSaveAcknowledgments.delete(uri);
+			pendingResolve();
+		}
+
 		let settings = await this.getDocumentSettings(document);
 		if (settings.lintOnSave) {
 			await this.validateSingle(document);
@@ -337,6 +372,15 @@ class PhpcsServer {
 	 * @return void
 	 */
 	private async onDidChangeDocument({ document }: { document: TextDocument }): Promise<void> {
+		const uri = document.uri;
+
+		// Resolve any pending document change watcher if version requirement is met
+		const pending = this.pendingDocumentChanges.get(uri);
+		if (pending && document.version >= pending.minVersion) {
+			this.pendingDocumentChanges.delete(uri);
+			pending.resolve();
+		}
+
 		let settings = await this.getDocumentSettings(document);
 		if (settings.lintOnType) {
 			await this.validateSingle(document);
@@ -729,6 +773,7 @@ class PhpcsServer {
 
 				// Compute hunks for per-change preview
 				const originalContent = currentDocument.getText();
+				const versionBeforeEdit = currentDocument.version;
 				const hunks = computeDiffHunks(originalContent, result.content);
 
 				if (hunks.length === 0) {
@@ -766,19 +811,19 @@ class PhpcsServer {
 				// Save after each accepted fix if setting is enabled
 				if (settings.phpcbfSaveOnFix) {
 					this.connection.sendNotification(proto.SaveDocumentNotification.type, { uri });
-					// Wait for save to complete before re-linting
-					await new Promise(resolve => setTimeout(resolve, 100));
+					// Wait for save acknowledgment via didSave notification before re-linting
+					await this.waitForSaveAcknowledgment(uri);
 				}
+
+				// Wait for document sync before re-linting
+				// The client applied edits, so we expect version > versionBeforeEdit
+				await this.waitForDocumentChange(uri, versionBeforeEdit + 1);
 
 				// Re-lint the document to refresh diagnostics
 				const updatedDocument = this.documents.get(uri);
 				if (updatedDocument) {
 					await this.validateSingle(updatedDocument);
 				}
-
-				// Continue loop to check for more fixes
-				// Small delay to allow document sync
-				await new Promise(resolve => setTimeout(resolve, 100));
 			}
 
 			if (hasUnfixableIssues) {
@@ -1157,6 +1202,70 @@ class PhpcsServer {
 			}
 		}
 		return strings.format(SR.UnknownErrorWhileValidatingTextDocument, URI.parse(document.uri).fsPath);
+	}
+
+	/**
+	 * Waits for save acknowledgment from the client via the didSave notification.
+	 *
+	 * This method creates a promise that resolves when the onDidSaveDocument handler
+	 * receives the didSave notification for the specified URI. A timeout ensures we
+	 * don't wait indefinitely if the notification is missed.
+	 *
+	 * @param uri The document URI to wait for save acknowledgment.
+	 * @returns A promise that resolves when save is acknowledged or timeout occurs.
+	 */
+	private waitForSaveAcknowledgment(uri: string): Promise<void> {
+		return new Promise((resolve) => {
+			// Set up the acknowledgment resolver
+			this.pendingSaveAcknowledgments.set(uri, resolve);
+
+			// Set up timeout fallback
+			setTimeout(() => {
+				if (this.pendingSaveAcknowledgments.has(uri)) {
+					this.pendingSaveAcknowledgments.delete(uri);
+					this.connection.console.log(
+						`Save acknowledgment timeout for ${uri}, proceeding anyway`
+					);
+					resolve();
+				}
+			}, SAVE_ACKNOWLEDGMENT_TIMEOUT_MS);
+		});
+	}
+
+	/**
+	 * Waits for a document version change via the didChange notification.
+	 *
+	 * This method creates a promise that resolves when the onDidChangeDocument handler
+	 * receives a didChange notification with a version >= minVersion. A timeout ensures
+	 * we don't wait indefinitely if the notification is missed.
+	 *
+	 * @param uri The document URI to wait for version change.
+	 * @param minVersion The minimum version number to wait for.
+	 * @returns A promise that resolves when version change is detected or timeout occurs.
+	 */
+	private waitForDocumentChange(uri: string, minVersion: number): Promise<void> {
+		return new Promise((resolve) => {
+			// Check if the document already has the required version
+			const currentDoc = this.documents.get(uri);
+			if (currentDoc && currentDoc.version >= minVersion) {
+				resolve();
+				return;
+			}
+
+			// Set up the change watcher
+			this.pendingDocumentChanges.set(uri, { minVersion, resolve });
+
+			// Set up timeout fallback
+			setTimeout(() => {
+				if (this.pendingDocumentChanges.has(uri)) {
+					this.pendingDocumentChanges.delete(uri);
+					this.connection.console.log(
+						`Document change timeout for ${uri} (waiting for version ${minVersion}), proceeding anyway`
+					);
+					resolve();
+				}
+			}, DOCUMENT_CHANGE_TIMEOUT_MS);
+		});
 	}
 
 	private getSource(uri: string): string

--- a/phpcs-server/src/server.ts
+++ b/phpcs-server/src/server.ts
@@ -39,7 +39,11 @@ import {
 	generateCodeActions,
 	createFullDocumentEdit,
 	PHPCBF_FIX_FILE_COMMAND,
+	PHPCBF_FIX_SINGLE_COMMAND,
 } from "./code-actions";
+import { computeDiffHunks } from "./diff-utils";
+import { correlateDiagnosticsToHunks, findHunksForDiagnostic } from "./hunk-correlation";
+import { applyHunks, validateHunks } from "./selective-fix";
 
 class PhpcsServer {
 	private openedFiles: Map<string, boolean>;
@@ -78,6 +82,7 @@ class PhpcsServer {
 		phpcbfEnable: true,
 		phpcbfExecutablePath: null,
 		phpcbfOnSave: false,
+		phpcbfSaveOnFix: false,
 		phpcbfShowDiff: false,
 		phpcbfTimeout: 60,
 	};
@@ -160,7 +165,7 @@ class PhpcsServer {
 				},
 				codeActionProvider: true,
 				executeCommandProvider: {
-					commands: [PHPCBF_FIX_FILE_COMMAND],
+					commands: [PHPCBF_FIX_FILE_COMMAND, PHPCBF_FIX_SINGLE_COMMAND],
 				},
 			}
 		});
@@ -369,21 +374,239 @@ class PhpcsServer {
 	 * @return void
 	 */
 	private async onExecuteCommand(params: ExecuteCommandParams): Promise<void> {
-		if (params.command !== PHPCBF_FIX_FILE_COMMAND) {
+		if (params.command === PHPCBF_FIX_FILE_COMMAND) {
+			const uri = params.arguments?.[0] as string | undefined;
+			if (!uri) {
+				return;
+			}
+
+			const document = this.documents.get(uri);
+			if (!document) {
+				return;
+			}
+
+			await this.fixDocument(document);
+		} else if (params.command === PHPCBF_FIX_SINGLE_COMMAND) {
+			const uri = params.arguments?.[0] as string | undefined;
+			const diagnostic = params.arguments?.[1] as Diagnostic | undefined;
+			if (!uri || !diagnostic) {
+				return;
+			}
+
+			const document = this.documents.get(uri);
+			if (!document) {
+				return;
+			}
+
+			await this.fixSingleIssue(document, diagnostic);
+		}
+	}
+
+	/**
+	 * Fix a single issue in a document using PHPCBF.
+	 * Runs PHPCBF to get the full fix, then applies only the hunk(s) relevant to the diagnostic.
+	 *
+	 * @param document The text document to fix.
+	 * @param targetDiagnostic The specific diagnostic to fix.
+	 * @return void
+	 */
+	private async fixSingleIssue(document: TextDocument, targetDiagnostic: Diagnostic): Promise<void> {
+		const uri = document.uri;
+
+		const settings = await this.getDocumentSettings(document);
+
+		if (!settings.phpcbfEnable) {
 			return;
 		}
 
-		const uri = params.arguments?.[0] as string | undefined;
-		if (!uri) {
+		const phpcbfPath = this.resolvePhpcbfPath(settings);
+		if (!phpcbfPath) {
+			this.connection.window.showWarningMessage(
+				'PHPCBF executable not found. Please set phpcs.phpcbfExecutablePath or ensure phpcbf is alongside phpcs.'
+			);
 			return;
 		}
 
-		const document = this.documents.get(uri);
-		if (!document) {
+		// Check if a fix is already in progress for this document.
+		if (this.fixingDocuments.has(uri)) {
+			this.connection.console.log(`[PHPCBF] Fix already in progress for: ${uri}, skipping duplicate request`);
 			return;
 		}
 
-		await this.fixDocument(document);
+		// Create the fix operation promise and track it
+		const fixOperation = this.executeSingleIssueFixOperation(document, settings, phpcbfPath, uri, targetDiagnostic);
+		this.fixingDocuments.set(uri, fixOperation);
+
+		try {
+			await fixOperation;
+		} finally {
+			// Always clean up the tracking entry when done
+			this.fixingDocuments.delete(uri);
+		}
+	}
+
+	/**
+	 * Execute the single issue fix operation for a document.
+	 *
+	 * @param document The text document to fix.
+	 * @param settings The PHPCS settings.
+	 * @param phpcbfPath Path to the PHPCBF executable.
+	 * @param uri The document URI.
+	 * @param targetDiagnostic The specific diagnostic to fix.
+	 * @return void
+	 */
+	private async executeSingleIssueFixOperation(
+		document: TextDocument,
+		settings: PhpcsSettings,
+		phpcbfPath: string,
+		uri: string,
+		targetDiagnostic: Diagnostic
+	): Promise<void> {
+		// Send start notification
+		this.connection.sendNotification(
+			proto.DidStartFixTextDocumentNotification.type,
+			{ textDocument: TextDocumentIdentifier.create(uri) }
+		);
+
+		let fixed = false;
+		let errorMessage: string | undefined;
+
+		try {
+			this.connection.console.log(strings.format(SR.PhpcbfFixingDocument, uri));
+			const fixer = await PhpcbfFixer.create(phpcbfPath);
+			fixer.setLogger((message) => this.connection.console.log(message));
+
+			// Get the fully fixed content from PHPCBF
+			const result = await fixer.fix(document, settings);
+
+			if (result.error) {
+				errorMessage = result.error;
+				this.connection.window.showErrorMessage(strings.format(SR.PhpcbfErrorMessage, result.error));
+				return;
+			}
+
+			if (!result.fixed) {
+				this.connection.console.log(`[PHPCBF] No fixes available for: ${uri}`);
+				return;
+			}
+
+			const originalContent = document.getText();
+
+			// Compute diff hunks between original and fully fixed content
+			const hunks = computeDiffHunks(originalContent, result.content);
+
+			this.connection.console.log(`[PHPCBF] Computed ${hunks.length} hunks for single-issue fix`);
+			for (const hunk of hunks) {
+				this.connection.console.log(`[PHPCBF]   Hunk: lines ${hunk.originalStart}-${hunk.originalStart + hunk.originalLength} (${hunk.originalLength} removed, ${hunk.modifiedLength} added)`);
+			}
+
+			if (hunks.length === 0) {
+				this.connection.console.log(`[PHPCBF] No hunks computed for: ${uri}`);
+				return;
+			}
+
+			// Get all diagnostics for correlation
+			const allDiagnostics = this.documentDiagnostics.get(uri) || [];
+			this.connection.console.log(`[PHPCBF] Target diagnostic: line ${targetDiagnostic.range.start.line}, message: "${targetDiagnostic.message.substring(0, 50)}..."`);
+			this.connection.console.log(`[PHPCBF] Document has ${allDiagnostics.length} stored diagnostics`);
+
+			// Correlate hunks to diagnostics
+			const correlations = correlateDiagnosticsToHunks(hunks, allDiagnostics);
+			for (const corr of correlations) {
+				this.connection.console.log(`[PHPCBF]   Correlation: hunk at line ${corr.hunk.originalStart} has ${corr.diagnostics.length} diagnostics (${corr.confidence})`);
+			}
+
+			// Find hunks for the specific diagnostic
+			const relevantHunks = findHunksForDiagnostic(correlations, targetDiagnostic);
+			this.connection.console.log(`[PHPCBF] Found ${relevantHunks.length} relevant hunks for target diagnostic`);
+
+			if (relevantHunks.length === 0) {
+				// No hunk found for this diagnostic - might be a side effect of another fix
+				// Log more details to help diagnose
+				this.connection.console.log(`[PHPCBF] No hunk found for diagnostic at line ${targetDiagnostic.range.start.line}`);
+				this.connection.console.log(`[PHPCBF] Target diagnostic details: ${JSON.stringify(targetDiagnostic.range)}`);
+
+				// Check if any hunk covers this line directly
+				for (const hunk of hunks) {
+					const coversLine = targetDiagnostic.range.start.line >= hunk.originalStart &&
+						targetDiagnostic.range.start.line < hunk.originalStart + Math.max(hunk.originalLength, 1);
+					this.connection.console.log(`[PHPCBF]   Hunk ${hunk.originalStart}-${hunk.originalStart + hunk.originalLength} covers line ${targetDiagnostic.range.start.line}? ${coversLine}`);
+				}
+
+				this.connection.window.showWarningMessage(
+					'Could not isolate this specific fix. The fix may depend on other changes. Use "Fix all" to apply all fixes.'
+				);
+				return;
+			}
+
+			// Validate that hunks can be applied
+			const validation = validateHunks(originalContent, relevantHunks);
+			if (!validation.valid) {
+				this.connection.console.log(`[PHPCBF] Hunk validation failed: ${validation.error}`);
+				this.connection.window.showErrorMessage(`Cannot apply fix: ${validation.error}`);
+				return;
+			}
+
+			// Apply only the relevant hunks
+			const partiallyFixedContent = applyHunks(originalContent, relevantHunks);
+
+			// Check if diff preview is enabled
+			if (settings.phpcbfShowDiff) {
+				const shouldApply = await this.connection.sendRequest(
+					proto.ShowDiffPreviewRequest.type,
+					{
+						uri,
+						originalContent,
+						fixedContent: partiallyFixedContent,
+						targetLine: targetDiagnostic.range.start.line,
+					}
+				);
+
+				if (!shouldApply) {
+					this.connection.console.log(strings.format(SR.PhpcbfDiffCancelled, uri));
+					return;
+				}
+			}
+
+			// Apply the fix using workspace edit
+			const edit = createFullDocumentEdit(document, partiallyFixedContent);
+			const applied = await this.connection.workspace.applyEdit({
+				changes: {
+					[uri]: [edit],
+				},
+			});
+
+			if (applied.applied) {
+				fixed = true;
+				this.connection.console.log(`[PHPCBF] Single issue fix applied to: ${uri}`);
+
+				// Re-lint the document to refresh diagnostics
+				const updatedDocument = this.documents.get(uri);
+				if (updatedDocument) {
+					await this.validateSingle(updatedDocument);
+				}
+
+				// Request the client to save the document if setting is enabled
+				if (settings.phpcbfSaveOnFix) {
+					this.connection.sendNotification(proto.SaveDocumentNotification.type, { uri });
+				}
+			} else {
+				this.connection.console.warn(strings.format(SR.PhpcbfFixFailed, uri));
+			}
+		} catch (error) {
+			errorMessage = error instanceof Error ? error.message : String(error);
+			this.connection.console.error(`[PHPCBF] Error fixing single issue: ${errorMessage}`);
+		} finally {
+			// Send end notification
+			this.connection.sendNotification(
+				proto.DidEndFixTextDocumentNotification.type,
+				{
+					textDocument: TextDocumentIdentifier.create(uri),
+					fixed,
+					error: errorMessage,
+				}
+			);
+		}
 	}
 
 	/**
@@ -504,6 +727,11 @@ class PhpcsServer {
 					const updatedDocument = this.documents.get(uri);
 					if (updatedDocument) {
 						await this.validateSingle(updatedDocument);
+					}
+
+					// Request the client to save the document if setting is enabled
+					if (settings.phpcbfSaveOnFix) {
+						this.connection.sendNotification(proto.SaveDocumentNotification.type, { uri });
 					}
 				} else {
 					this.connection.console.warn(strings.format(SR.PhpcbfFixFailed, uri));

--- a/phpcs-server/src/settings.ts
+++ b/phpcs-server/src/settings.ts
@@ -27,6 +27,5 @@ export interface PhpcsSettings {
 	phpcbfExecutablePath: string | null;
 	phpcbfOnSave: boolean;
 	phpcbfSaveOnFix: boolean;
-	phpcbfShowDiff: boolean;
 	phpcbfTimeout: number;
 }

--- a/phpcs-server/src/settings.ts
+++ b/phpcs-server/src/settings.ts
@@ -26,6 +26,7 @@ export interface PhpcsSettings {
 	phpcbfEnable: boolean;
 	phpcbfExecutablePath: string | null;
 	phpcbfOnSave: boolean;
+	phpcbfSaveOnFix: boolean;
 	phpcbfShowDiff: boolean;
 	phpcbfTimeout: number;
 }

--- a/phpcs-server/src/settings.ts
+++ b/phpcs-server/src/settings.ts
@@ -26,5 +26,6 @@ export interface PhpcsSettings {
 	phpcbfEnable: boolean;
 	phpcbfExecutablePath: string | null;
 	phpcbfOnSave: boolean;
+	phpcbfShowDiff: boolean;
 	phpcbfTimeout: number;
 }

--- a/phpcs-server/src/strings.ts
+++ b/phpcs-server/src/strings.ts
@@ -29,6 +29,7 @@ export class StringResources {
 	static readonly PhpcbfUnfixableIssues: string = 'PHPCBF: Some issues could not be automatically fixed.';
 	static readonly PhpcbfError: string = '[PHPCBF] Error: {0}';
 	static readonly PhpcbfErrorMessage: string = 'PHPCBF: {0}';
+	static readonly PhpcbfDiffCancelled: string = '[PHPCBF] User cancelled fix for: {0}';
 
 	static readonly UnknownExecutionError: string = 'Unknown error ocurred. Please verify that {0} returns a valid json object.';
 	static readonly CodingStandardNotInstalledError: string = 'The "{0}" coding standard is not installed. Please review your configuration an try again.';

--- a/phpcs-server/src/strings.ts
+++ b/phpcs-server/src/strings.ts
@@ -30,6 +30,10 @@ export class StringResources {
 	static readonly PhpcbfError: string = '[PHPCBF] Error: {0}';
 	static readonly PhpcbfErrorMessage: string = 'PHPCBF: {0}';
 	static readonly PhpcbfDiffCancelled: string = '[PHPCBF] User cancelled fix for: {0}';
+	static readonly PhpcbfExecutableNotFound: string = 'PHPCBF executable not found. Please set phpcs.phpcbfExecutablePath or ensure phpcbf is alongside phpcs.';
+	static readonly PhpcbfNoFixesAvailable: string = 'No fixes available. The issue may have already been fixed or is not auto-fixable.';
+	static readonly PhpcbfCannotIsolateFix: string = 'Could not isolate this specific fix. The fix may depend on other changes. Use "Fix all" to apply all fixes.';
+	static readonly PhpcbfCannotApplyFix: string = 'Cannot apply fix: {0}';
 
 	static readonly UnknownExecutionError: string = 'Unknown error ocurred. Please verify that {0} returns a valid json object.';
 	static readonly CodingStandardNotInstalledError: string = 'The "{0}" coding standard is not installed. Please review your configuration an try again.';

--- a/phpcs-server/test/code-actions.test.ts
+++ b/phpcs-server/test/code-actions.test.ts
@@ -16,8 +16,10 @@ import {
 	generateCodeActions,
 	isDiagnosticFixable,
 	createFixOnlyThisIssueAction,
+	createPreviewFixesAction,
 	PHPCBF_FIX_FILE_COMMAND,
 	PHPCBF_FIX_SINGLE_COMMAND,
+	PHPCBF_PREVIEW_COMMAND,
 	PhpcsDiagnosticData,
 } from '../src/code-actions';
 
@@ -195,8 +197,9 @@ suite('Code Actions', () => {
 			};
 			const actions = generateCodeActions(params, document, [diagnostic]);
 
-			assert.strictEqual(actions.length, 1);
-			assert.ok(actions[0].title.includes('PHPCBF'));
+			// "Fix all" + "Preview fixes"
+			assert.strictEqual(actions.length, 2);
+			assert.ok(actions.some(a => a.title.includes('PHPCBF')));
 		});
 
 		test('should not return action when only other diagnostics in range', () => {
@@ -297,6 +300,48 @@ suite('Code Actions', () => {
 
 	});
 
+	suite('createPreviewFixesAction', () => {
+
+		test('should create action when there are PHPCS diagnostics', () => {
+			const document = createTestDocument('<?php echo 1;');
+			const diagnostics = [createPhpcsDiagnostic('Error 1')];
+			const action = createPreviewFixesAction(document, diagnostics);
+
+			assert.ok(action);
+			assert.ok(action!.title.includes('Preview fixes'));
+			assert.strictEqual(action!.kind, CodeActionKind.QuickFix);
+			assert.ok(action!.command);
+			assert.strictEqual(action!.command!.command, PHPCBF_PREVIEW_COMMAND);
+		});
+
+		test('should return null when no PHPCS diagnostics', () => {
+			const document = createTestDocument('<?php echo 1;');
+			const diagnostics = [createOtherDiagnostic('Error 1')];
+			const action = createPreviewFixesAction(document, diagnostics);
+
+			assert.strictEqual(action, null);
+		});
+
+		test('should return null for empty diagnostics', () => {
+			const document = createTestDocument('<?php echo 1;');
+			const action = createPreviewFixesAction(document, []);
+
+			assert.strictEqual(action, null);
+		});
+
+		test('should include document URI in command arguments', () => {
+			const uri = 'file:///path/to/test.php';
+			const document = createTestDocument('<?php echo 1;', uri);
+			const diagnostics = [createPhpcsDiagnostic('Error 1')];
+			const action = createPreviewFixesAction(document, diagnostics);
+
+			assert.ok(action);
+			assert.ok(action!.command);
+			assert.deepStrictEqual(action!.command!.arguments, [uri]);
+		});
+
+	});
+
 	suite('generateCodeActions with single issue actions', () => {
 
 		test('should return both action types for fixable diagnostic', () => {
@@ -309,10 +354,11 @@ suite('Code Actions', () => {
 			};
 			const actions = generateCodeActions(params, document, [diagnostic]);
 
-			// "Fix only this issue" + "Fix all"
-			assert.strictEqual(actions.length, 2);
+			// "Fix only this issue" + "Fix all" + "Preview fixes"
+			assert.strictEqual(actions.length, 3);
 			assert.ok(actions.some(a => a.title.includes('Fix only this issue')));
 			assert.ok(actions.some(a => a.title.includes('Fix all')));
+			assert.ok(actions.some(a => a.title.includes('Preview fixes')));
 		});
 
 		test('should have Fix only this issue listed first', () => {
@@ -329,7 +375,7 @@ suite('Code Actions', () => {
 			assert.ok(actions[0].title.includes('Fix only this issue'));
 		});
 
-		test('should return only fix all action for non-fixable diagnostic', () => {
+		test('should return only fix all and preview actions for non-fixable diagnostic', () => {
 			const document = createTestDocument('<?php echo 1;');
 			const diagnostic = createPhpcsDiagnostic('Error 1', 1, false);
 			const params: CodeActionParams = {
@@ -339,8 +385,10 @@ suite('Code Actions', () => {
 			};
 			const actions = generateCodeActions(params, document, [diagnostic]);
 
-			assert.strictEqual(actions.length, 1);
-			assert.ok(actions[0].title.includes('Fix all'));
+			// "Fix all" + "Preview fixes"
+			assert.strictEqual(actions.length, 2);
+			assert.ok(actions.some(a => a.title.includes('Fix all')));
+			assert.ok(actions.some(a => a.title.includes('Preview fixes')));
 		});
 
 		test('should return multiple actions for multiple fixable diagnostics', () => {
@@ -354,8 +402,8 @@ suite('Code Actions', () => {
 			};
 			const actions = generateCodeActions(params, document, [diag1, diag2]);
 
-			// 2 "Fix only this issue" + 1 "Fix all"
-			assert.strictEqual(actions.length, 3);
+			// 2 "Fix only this issue" + 1 "Fix all" + 1 "Preview fixes"
+			assert.strictEqual(actions.length, 4);
 			const fixOnlyActions = actions.filter(a => a.title.includes('Fix only this issue'));
 			assert.strictEqual(fixOnlyActions.length, 2);
 		});

--- a/phpcs-server/test/code-actions.test.ts
+++ b/phpcs-server/test/code-actions.test.ts
@@ -15,8 +15,9 @@ import {
 	createFullDocumentEdit,
 	generateCodeActions,
 	isDiagnosticFixable,
-	createFixSingleIssueAction,
+	createFixOnlyThisIssueAction,
 	PHPCBF_FIX_FILE_COMMAND,
+	PHPCBF_FIX_SINGLE_COMMAND,
 	PhpcsDiagnosticData,
 } from '../src/code-actions';
 
@@ -249,44 +250,45 @@ suite('Code Actions', () => {
 
 	});
 
-	suite('createFixSingleIssueAction', () => {
+	suite('createFixOnlyThisIssueAction', () => {
 
 		test('should create action for fixable diagnostic', () => {
 			const document = createTestDocument('<?php echo 1;');
 			const diagnostic = createPhpcsDiagnostic('Error 1', 1, true);
-			const action = createFixSingleIssueAction(document, diagnostic);
+			const action = createFixOnlyThisIssueAction(document, diagnostic);
 
 			assert.ok(action);
-			assert.ok(action!.title.includes('Fix this and other'));
+			assert.ok(action!.title.includes('Fix only this issue'));
 			assert.strictEqual(action!.kind, CodeActionKind.QuickFix);
 			assert.strictEqual(action!.isPreferred, false);
 			assert.ok(action!.command);
-			assert.strictEqual(action!.command!.command, PHPCBF_FIX_FILE_COMMAND);
+			assert.strictEqual(action!.command!.command, PHPCBF_FIX_SINGLE_COMMAND);
 		});
 
 		test('should return null for non-fixable diagnostic', () => {
 			const document = createTestDocument('<?php echo 1;');
 			const diagnostic = createPhpcsDiagnostic('Error 1', 1, false);
-			const action = createFixSingleIssueAction(document, diagnostic);
+			const action = createFixOnlyThisIssueAction(document, diagnostic);
 
 			assert.strictEqual(action, null);
 		});
 
-		test('should include document URI in command arguments', () => {
+		test('should include document URI and diagnostic in command arguments', () => {
 			const uri = 'file:///path/to/test.php';
 			const document = createTestDocument('<?php echo 1;', uri);
 			const diagnostic = createPhpcsDiagnostic('Error 1', 1, true);
-			const action = createFixSingleIssueAction(document, diagnostic);
+			const action = createFixOnlyThisIssueAction(document, diagnostic);
 
 			assert.ok(action);
 			assert.ok(action!.command);
-			assert.deepStrictEqual(action!.command!.arguments, [uri]);
+			assert.strictEqual(action!.command!.arguments![0], uri);
+			assert.strictEqual(action!.command!.arguments![1], diagnostic);
 		});
 
 		test('should only include the single diagnostic in action', () => {
 			const document = createTestDocument('<?php echo 1;');
 			const diagnostic = createPhpcsDiagnostic('Error 1', 1, true);
-			const action = createFixSingleIssueAction(document, diagnostic);
+			const action = createFixOnlyThisIssueAction(document, diagnostic);
 
 			assert.ok(action);
 			assert.strictEqual(action!.diagnostics!.length, 1);
@@ -297,7 +299,7 @@ suite('Code Actions', () => {
 
 	suite('generateCodeActions with single issue actions', () => {
 
-		test('should return single issue action and fix all action for fixable diagnostic', () => {
+		test('should return both action types for fixable diagnostic', () => {
 			const document = createTestDocument('<?php echo 1;');
 			const diagnostic = createPhpcsDiagnostic('Error 1', 1, true);
 			const params: CodeActionParams = {
@@ -307,9 +309,24 @@ suite('Code Actions', () => {
 			};
 			const actions = generateCodeActions(params, document, [diagnostic]);
 
+			// "Fix only this issue" + "Fix all"
 			assert.strictEqual(actions.length, 2);
-			assert.ok(actions.some(a => a.title.includes('Fix this and other')));
+			assert.ok(actions.some(a => a.title.includes('Fix only this issue')));
 			assert.ok(actions.some(a => a.title.includes('Fix all')));
+		});
+
+		test('should have Fix only this issue listed first', () => {
+			const document = createTestDocument('<?php echo 1;');
+			const diagnostic = createPhpcsDiagnostic('Error 1', 1, true);
+			const params: CodeActionParams = {
+				textDocument: { uri: document.uri },
+				range: { start: { line: 0, character: 0 }, end: { line: 0, character: 10 } },
+				context: { diagnostics: [diagnostic] },
+			};
+			const actions = generateCodeActions(params, document, [diagnostic]);
+
+			// "Fix only this issue" should be first in the list
+			assert.ok(actions[0].title.includes('Fix only this issue'));
 		});
 
 		test('should return only fix all action for non-fixable diagnostic', () => {
@@ -326,7 +343,7 @@ suite('Code Actions', () => {
 			assert.ok(actions[0].title.includes('Fix all'));
 		});
 
-		test('should return multiple single issue actions for multiple fixable diagnostics', () => {
+		test('should return multiple actions for multiple fixable diagnostics', () => {
 			const document = createTestDocument('<?php echo 1;');
 			const diag1 = createPhpcsDiagnostic('Error 1', 1, true);
 			const diag2 = createPhpcsDiagnostic('Error 2', 1, true);
@@ -337,10 +354,10 @@ suite('Code Actions', () => {
 			};
 			const actions = generateCodeActions(params, document, [diag1, diag2]);
 
-			// 2 single issue actions + 1 fix all action
+			// 2 "Fix only this issue" + 1 "Fix all"
 			assert.strictEqual(actions.length, 3);
-			const singleActions = actions.filter(a => a.title.includes('Fix this and other'));
-			assert.strictEqual(singleActions.length, 2);
+			const fixOnlyActions = actions.filter(a => a.title.includes('Fix only this issue'));
+			assert.strictEqual(fixOnlyActions.length, 2);
 		});
 
 	});

--- a/phpcs-server/test/code-actions.test.ts
+++ b/phpcs-server/test/code-actions.test.ts
@@ -14,7 +14,10 @@ import {
 	createFixAllInFileAction,
 	createFullDocumentEdit,
 	generateCodeActions,
+	isDiagnosticFixable,
+	createFixSingleIssueAction,
 	PHPCBF_FIX_FILE_COMMAND,
+	PhpcsDiagnosticData,
 } from '../src/code-actions';
 
 suite('Code Actions', () => {
@@ -23,8 +26,8 @@ suite('Code Actions', () => {
 		return TextDocument.create(uri, 'php', 1, content);
 	};
 
-	const createPhpcsDiagnostic = (message: string, line: number = 1): Diagnostic => {
-		return {
+	const createPhpcsDiagnostic = (message: string, line: number = 1, fixable: boolean = false): Diagnostic => {
+		const diagnostic: Diagnostic = {
 			range: {
 				start: { line: line - 1, character: 0 },
 				end: { line: line - 1, character: 10 },
@@ -33,6 +36,10 @@ suite('Code Actions', () => {
 			severity: DiagnosticSeverity.Error,
 			source: 'phpcs',
 		};
+		if (fixable) {
+			diagnostic.data = { fixable: true, source: 'TestSniff.Rule' } as PhpcsDiagnosticData;
+		}
+		return diagnostic;
 	};
 
 	const createOtherDiagnostic = (message: string, line: number = 1): Diagnostic => {
@@ -213,6 +220,127 @@ suite('Code Actions', () => {
 		test('should be a valid command string', () => {
 			assert.strictEqual(typeof PHPCBF_FIX_FILE_COMMAND, 'string');
 			assert.ok(PHPCBF_FIX_FILE_COMMAND.length > 0);
+		});
+
+	});
+
+	suite('isDiagnosticFixable', () => {
+
+		test('should return true for fixable diagnostic', () => {
+			const diagnostic = createPhpcsDiagnostic('Error 1', 1, true);
+			assert.strictEqual(isDiagnosticFixable(diagnostic), true);
+		});
+
+		test('should return false for non-fixable diagnostic', () => {
+			const diagnostic = createPhpcsDiagnostic('Error 1', 1, false);
+			assert.strictEqual(isDiagnosticFixable(diagnostic), false);
+		});
+
+		test('should return false when data is undefined', () => {
+			const diagnostic = createPhpcsDiagnostic('Error 1');
+			assert.strictEqual(isDiagnosticFixable(diagnostic), false);
+		});
+
+		test('should return false when fixable is explicitly false', () => {
+			const diagnostic = createPhpcsDiagnostic('Error 1');
+			diagnostic.data = { fixable: false } as PhpcsDiagnosticData;
+			assert.strictEqual(isDiagnosticFixable(diagnostic), false);
+		});
+
+	});
+
+	suite('createFixSingleIssueAction', () => {
+
+		test('should create action for fixable diagnostic', () => {
+			const document = createTestDocument('<?php echo 1;');
+			const diagnostic = createPhpcsDiagnostic('Error 1', 1, true);
+			const action = createFixSingleIssueAction(document, diagnostic);
+
+			assert.ok(action);
+			assert.ok(action!.title.includes('Fix this issue'));
+			assert.strictEqual(action!.kind, CodeActionKind.QuickFix);
+			assert.strictEqual(action!.isPreferred, false);
+			assert.ok(action!.command);
+			assert.strictEqual(action!.command!.command, PHPCBF_FIX_FILE_COMMAND);
+		});
+
+		test('should return null for non-fixable diagnostic', () => {
+			const document = createTestDocument('<?php echo 1;');
+			const diagnostic = createPhpcsDiagnostic('Error 1', 1, false);
+			const action = createFixSingleIssueAction(document, diagnostic);
+
+			assert.strictEqual(action, null);
+		});
+
+		test('should include document URI in command arguments', () => {
+			const uri = 'file:///path/to/test.php';
+			const document = createTestDocument('<?php echo 1;', uri);
+			const diagnostic = createPhpcsDiagnostic('Error 1', 1, true);
+			const action = createFixSingleIssueAction(document, diagnostic);
+
+			assert.ok(action);
+			assert.ok(action!.command);
+			assert.deepStrictEqual(action!.command!.arguments, [uri]);
+		});
+
+		test('should only include the single diagnostic in action', () => {
+			const document = createTestDocument('<?php echo 1;');
+			const diagnostic = createPhpcsDiagnostic('Error 1', 1, true);
+			const action = createFixSingleIssueAction(document, diagnostic);
+
+			assert.ok(action);
+			assert.strictEqual(action!.diagnostics!.length, 1);
+			assert.strictEqual(action!.diagnostics![0], diagnostic);
+		});
+
+	});
+
+	suite('generateCodeActions with single issue actions', () => {
+
+		test('should return single issue action and fix all action for fixable diagnostic', () => {
+			const document = createTestDocument('<?php echo 1;');
+			const diagnostic = createPhpcsDiagnostic('Error 1', 1, true);
+			const params: CodeActionParams = {
+				textDocument: { uri: document.uri },
+				range: { start: { line: 0, character: 0 }, end: { line: 0, character: 10 } },
+				context: { diagnostics: [diagnostic] },
+			};
+			const actions = generateCodeActions(params, document, [diagnostic]);
+
+			assert.strictEqual(actions.length, 2);
+			assert.ok(actions.some(a => a.title.includes('Fix this issue')));
+			assert.ok(actions.some(a => a.title.includes('Fix all')));
+		});
+
+		test('should return only fix all action for non-fixable diagnostic', () => {
+			const document = createTestDocument('<?php echo 1;');
+			const diagnostic = createPhpcsDiagnostic('Error 1', 1, false);
+			const params: CodeActionParams = {
+				textDocument: { uri: document.uri },
+				range: { start: { line: 0, character: 0 }, end: { line: 0, character: 10 } },
+				context: { diagnostics: [diagnostic] },
+			};
+			const actions = generateCodeActions(params, document, [diagnostic]);
+
+			assert.strictEqual(actions.length, 1);
+			assert.ok(actions[0].title.includes('Fix all'));
+		});
+
+		test('should return multiple single issue actions for multiple fixable diagnostics', () => {
+			const document = createTestDocument('<?php echo 1;');
+			const diag1 = createPhpcsDiagnostic('Error 1', 1, true);
+			const diag2 = createPhpcsDiagnostic('Error 2', 1, true);
+			const params: CodeActionParams = {
+				textDocument: { uri: document.uri },
+				range: { start: { line: 0, character: 0 }, end: { line: 0, character: 10 } },
+				context: { diagnostics: [diag1, diag2] },
+			};
+			const actions = generateCodeActions(params, document, [diag1, diag2]);
+
+			// 2 single issue actions + 1 fix all action
+			assert.strictEqual(actions.length, 3);
+			const singleActions = actions.filter(a => a.title.includes('Fix this issue'));
+			assert.strictEqual(singleActions.length, 2);
 		});
 
 	});

--- a/phpcs-server/test/code-actions.test.ts
+++ b/phpcs-server/test/code-actions.test.ts
@@ -257,7 +257,7 @@ suite('Code Actions', () => {
 			const action = createFixSingleIssueAction(document, diagnostic);
 
 			assert.ok(action);
-			assert.ok(action!.title.includes('Fix this issue'));
+			assert.ok(action!.title.includes('Fix this and other'));
 			assert.strictEqual(action!.kind, CodeActionKind.QuickFix);
 			assert.strictEqual(action!.isPreferred, false);
 			assert.ok(action!.command);
@@ -308,7 +308,7 @@ suite('Code Actions', () => {
 			const actions = generateCodeActions(params, document, [diagnostic]);
 
 			assert.strictEqual(actions.length, 2);
-			assert.ok(actions.some(a => a.title.includes('Fix this issue')));
+			assert.ok(actions.some(a => a.title.includes('Fix this and other')));
 			assert.ok(actions.some(a => a.title.includes('Fix all')));
 		});
 
@@ -339,7 +339,7 @@ suite('Code Actions', () => {
 
 			// 2 single issue actions + 1 fix all action
 			assert.strictEqual(actions.length, 3);
-			const singleActions = actions.filter(a => a.title.includes('Fix this issue'));
+			const singleActions = actions.filter(a => a.title.includes('Fix this and other'));
 			assert.strictEqual(singleActions.length, 2);
 		});
 

--- a/phpcs-server/test/diff-utils.test.ts
+++ b/phpcs-server/test/diff-utils.test.ts
@@ -152,6 +152,88 @@ suite('Diff Utils', () => {
 			assert.deepStrictEqual(hunks[0].modifiedLines, ['new1', 'new2', 'new3']);
 		});
 
+		test('should handle completely different content', () => {
+			const original = 'a\nb\nc';
+			const modified = 'x\ny\nz';
+			const hunks = computeDiffHunks(original, modified);
+
+			// All lines are different, should result in a single hunk
+			assert.strictEqual(hunks.length, 1);
+			assert.strictEqual(hunks[0].originalLength, 3);
+			assert.strictEqual(hunks[0].modifiedLength, 3);
+		});
+
+		test('should handle insertion at very beginning', () => {
+			const original = 'line2\nline3';
+			const modified = 'line1\nline2\nline3';
+			const hunks = computeDiffHunks(original, modified);
+
+			assert.strictEqual(hunks.length, 1);
+			assert.strictEqual(hunks[0].originalStart, 0);
+			assert.strictEqual(hunks[0].originalLength, 0);
+			assert.strictEqual(hunks[0].modifiedLength, 1);
+			assert.deepStrictEqual(hunks[0].modifiedLines, ['line1']);
+		});
+
+		test('should handle insertion at very end', () => {
+			const original = 'line1\nline2';
+			const modified = 'line1\nline2\nline3';
+			const hunks = computeDiffHunks(original, modified);
+
+			assert.strictEqual(hunks.length, 1);
+			assert.strictEqual(hunks[0].originalLength, 0);
+			assert.strictEqual(hunks[0].modifiedLength, 1);
+			assert.deepStrictEqual(hunks[0].modifiedLines, ['line3']);
+		});
+
+		test('should handle deletion at very beginning', () => {
+			const original = 'line1\nline2\nline3';
+			const modified = 'line2\nline3';
+			const hunks = computeDiffHunks(original, modified);
+
+			assert.strictEqual(hunks.length, 1);
+			assert.strictEqual(hunks[0].originalStart, 0);
+			assert.strictEqual(hunks[0].originalLength, 1);
+			assert.strictEqual(hunks[0].modifiedLength, 0);
+			assert.deepStrictEqual(hunks[0].originalLines, ['line1']);
+		});
+
+		test('should handle deletion at very end', () => {
+			const original = 'line1\nline2\nline3';
+			const modified = 'line1\nline2';
+			const hunks = computeDiffHunks(original, modified);
+
+			assert.strictEqual(hunks.length, 1);
+			assert.strictEqual(hunks[0].originalLength, 1);
+			assert.strictEqual(hunks[0].modifiedLength, 0);
+			assert.deepStrictEqual(hunks[0].originalLines, ['line3']);
+		});
+
+		test('should handle single line original and modified', () => {
+			const original = 'single';
+			const modified = 'changed';
+			const hunks = computeDiffHunks(original, modified);
+
+			assert.strictEqual(hunks.length, 1);
+			assert.deepStrictEqual(hunks[0].originalLines, ['single']);
+			assert.deepStrictEqual(hunks[0].modifiedLines, ['changed']);
+		});
+
+		test('should handle LCS backtracking with equal dp values', () => {
+			// This tests the case where dp[i-1][j] equals dp[i][j-1]
+			// The algorithm should prefer one direction consistently
+			const original = 'a\nc\ne';
+			const modified = 'b\nc\nd';
+			const hunks = computeDiffHunks(original, modified);
+
+			// Both have 'c' in common
+			assert.ok(hunks.length >= 1);
+			// Verify 'c' is preserved (not in any hunk's changes)
+			const allOriginalLines = hunks.flatMap(h => h.originalLines);
+			const allModifiedLines = hunks.flatMap(h => h.modifiedLines);
+			assert.ok(!allOriginalLines.includes('c') || !allModifiedLines.includes('c'));
+		});
+
 	});
 
 	suite('isLineInHunkRange', () => {

--- a/phpcs-server/test/diff-utils.test.ts
+++ b/phpcs-server/test/diff-utils.test.ts
@@ -228,10 +228,11 @@ suite('Diff Utils', () => {
 
 			// Both have 'c' in common
 			assert.ok(hunks.length >= 1);
-			// Verify 'c' is preserved (not in any hunk's changes)
+			// Verify 'c' is preserved (not in any hunk's changes on either side)
 			const allOriginalLines = hunks.flatMap(h => h.originalLines);
 			const allModifiedLines = hunks.flatMap(h => h.modifiedLines);
-			assert.ok(!allOriginalLines.includes('c') || !allModifiedLines.includes('c'));
+			assert.strictEqual(allOriginalLines.includes('c'), false, "'c' should not be in original hunk lines");
+			assert.strictEqual(allModifiedLines.includes('c'), false, "'c' should not be in modified hunk lines");
 		});
 
 	});

--- a/phpcs-server/test/diff-utils.test.ts
+++ b/phpcs-server/test/diff-utils.test.ts
@@ -1,0 +1,236 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) John R. D'Orazio. All rights reserved.
+ * Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import * as assert from 'assert';
+import { computeDiffHunks, isLineInHunkRange, getHunkOriginalEnd, DiffHunk } from '../src/diff-utils';
+
+suite('Diff Utils', () => {
+
+	suite('computeDiffHunks', () => {
+
+		test('should return empty array for identical content', () => {
+			const content = 'line1\nline2\nline3';
+			const hunks = computeDiffHunks(content, content);
+			assert.strictEqual(hunks.length, 0);
+		});
+
+		test('should detect single line change', () => {
+			const original = 'line1\nline2\nline3';
+			const modified = 'line1\nmodified\nline3';
+			const hunks = computeDiffHunks(original, modified);
+
+			assert.strictEqual(hunks.length, 1);
+			assert.strictEqual(hunks[0].originalStart, 1);
+			assert.strictEqual(hunks[0].originalLength, 1);
+			assert.strictEqual(hunks[0].modifiedLength, 1);
+			assert.deepStrictEqual(hunks[0].originalLines, ['line2']);
+			assert.deepStrictEqual(hunks[0].modifiedLines, ['modified']);
+		});
+
+		test('should detect single line deletion', () => {
+			const original = 'line1\nline2\nline3';
+			const modified = 'line1\nline3';
+			const hunks = computeDiffHunks(original, modified);
+
+			assert.strictEqual(hunks.length, 1);
+			assert.strictEqual(hunks[0].originalStart, 1);
+			assert.strictEqual(hunks[0].originalLength, 1);
+			assert.strictEqual(hunks[0].modifiedLength, 0);
+			assert.deepStrictEqual(hunks[0].originalLines, ['line2']);
+			assert.deepStrictEqual(hunks[0].modifiedLines, []);
+		});
+
+		test('should detect single line insertion', () => {
+			const original = 'line1\nline3';
+			const modified = 'line1\nline2\nline3';
+			const hunks = computeDiffHunks(original, modified);
+
+			assert.strictEqual(hunks.length, 1);
+			assert.strictEqual(hunks[0].originalLength, 0);
+			assert.strictEqual(hunks[0].modifiedLength, 1);
+			assert.deepStrictEqual(hunks[0].originalLines, []);
+			assert.deepStrictEqual(hunks[0].modifiedLines, ['line2']);
+		});
+
+		test('should detect multiple line change as single hunk', () => {
+			const original = 'line1\nline2\nline3\nline4';
+			const modified = 'line1\nchanged2\nchanged3\nline4';
+			const hunks = computeDiffHunks(original, modified);
+
+			assert.strictEqual(hunks.length, 1);
+			assert.strictEqual(hunks[0].originalStart, 1);
+			assert.strictEqual(hunks[0].originalLength, 2);
+			assert.strictEqual(hunks[0].modifiedLength, 2);
+			assert.deepStrictEqual(hunks[0].originalLines, ['line2', 'line3']);
+			assert.deepStrictEqual(hunks[0].modifiedLines, ['changed2', 'changed3']);
+		});
+
+		test('should detect multiple separate hunks', () => {
+			const original = 'line1\nline2\nline3\nline4\nline5';
+			const modified = 'line1\nchanged2\nline3\nchanged4\nline5';
+			const hunks = computeDiffHunks(original, modified);
+
+			assert.strictEqual(hunks.length, 2);
+
+			// First hunk
+			assert.strictEqual(hunks[0].originalStart, 1);
+			assert.strictEqual(hunks[0].originalLength, 1);
+			assert.deepStrictEqual(hunks[0].originalLines, ['line2']);
+			assert.deepStrictEqual(hunks[0].modifiedLines, ['changed2']);
+
+			// Second hunk
+			assert.strictEqual(hunks[1].originalStart, 3);
+			assert.strictEqual(hunks[1].originalLength, 1);
+			assert.deepStrictEqual(hunks[1].originalLines, ['line4']);
+			assert.deepStrictEqual(hunks[1].modifiedLines, ['changed4']);
+		});
+
+		test('should handle changes at start of file', () => {
+			const original = 'line1\nline2\nline3';
+			const modified = 'changed1\nline2\nline3';
+			const hunks = computeDiffHunks(original, modified);
+
+			assert.strictEqual(hunks.length, 1);
+			assert.strictEqual(hunks[0].originalStart, 0);
+			assert.deepStrictEqual(hunks[0].originalLines, ['line1']);
+			assert.deepStrictEqual(hunks[0].modifiedLines, ['changed1']);
+		});
+
+		test('should handle changes at end of file', () => {
+			const original = 'line1\nline2\nline3';
+			const modified = 'line1\nline2\nchanged3';
+			const hunks = computeDiffHunks(original, modified);
+
+			assert.strictEqual(hunks.length, 1);
+			assert.strictEqual(hunks[0].originalStart, 2);
+			assert.deepStrictEqual(hunks[0].originalLines, ['line3']);
+			assert.deepStrictEqual(hunks[0].modifiedLines, ['changed3']);
+		});
+
+		test('should handle empty original content', () => {
+			const original = '';
+			const modified = 'line1\nline2';
+			const hunks = computeDiffHunks(original, modified);
+
+			assert.strictEqual(hunks.length, 1);
+			assert.strictEqual(hunks[0].originalLength, 1); // Empty string splits to ['']
+			assert.strictEqual(hunks[0].modifiedLength, 2);
+		});
+
+		test('should handle empty modified content', () => {
+			const original = 'line1\nline2';
+			const modified = '';
+			const hunks = computeDiffHunks(original, modified);
+
+			assert.strictEqual(hunks.length, 1);
+			assert.strictEqual(hunks[0].originalLength, 2);
+			assert.strictEqual(hunks[0].modifiedLength, 1); // Empty string splits to ['']
+		});
+
+		test('should handle whitespace-only changes', () => {
+			const original = 'line1\n    indented\nline3';
+			const modified = 'line1\n\tindented\nline3';
+			const hunks = computeDiffHunks(original, modified);
+
+			assert.strictEqual(hunks.length, 1);
+			assert.deepStrictEqual(hunks[0].originalLines, ['    indented']);
+			assert.deepStrictEqual(hunks[0].modifiedLines, ['\tindented']);
+		});
+
+		test('should handle mixed insertions and deletions in one hunk', () => {
+			const original = 'line1\nold1\nold2\nline4';
+			const modified = 'line1\nnew1\nnew2\nnew3\nline4';
+			const hunks = computeDiffHunks(original, modified);
+
+			assert.strictEqual(hunks.length, 1);
+			assert.strictEqual(hunks[0].originalLength, 2);
+			assert.strictEqual(hunks[0].modifiedLength, 3);
+			assert.deepStrictEqual(hunks[0].originalLines, ['old1', 'old2']);
+			assert.deepStrictEqual(hunks[0].modifiedLines, ['new1', 'new2', 'new3']);
+		});
+
+	});
+
+	suite('isLineInHunkRange', () => {
+
+		test('should return true for line within deletion range', () => {
+			const hunk: DiffHunk = {
+				originalStart: 5,
+				originalLength: 3,
+				modifiedStart: 5,
+				modifiedLength: 2,
+				originalLines: ['a', 'b', 'c'],
+				modifiedLines: ['x', 'y']
+			};
+
+			assert.strictEqual(isLineInHunkRange(hunk, 5), true);
+			assert.strictEqual(isLineInHunkRange(hunk, 6), true);
+			assert.strictEqual(isLineInHunkRange(hunk, 7), true);
+		});
+
+		test('should return false for line outside deletion range', () => {
+			const hunk: DiffHunk = {
+				originalStart: 5,
+				originalLength: 3,
+				modifiedStart: 5,
+				modifiedLength: 2,
+				originalLines: ['a', 'b', 'c'],
+				modifiedLines: ['x', 'y']
+			};
+
+			assert.strictEqual(isLineInHunkRange(hunk, 4), false);
+			assert.strictEqual(isLineInHunkRange(hunk, 8), false);
+		});
+
+		test('should handle pure insertion hunk', () => {
+			const hunk: DiffHunk = {
+				originalStart: 3,
+				originalLength: 0,
+				modifiedStart: 3,
+				modifiedLength: 2,
+				originalLines: [],
+				modifiedLines: ['new1', 'new2']
+			};
+
+			// Pure insertion only matches the exact insertion point
+			assert.strictEqual(isLineInHunkRange(hunk, 3), true);
+			assert.strictEqual(isLineInHunkRange(hunk, 2), false);
+			assert.strictEqual(isLineInHunkRange(hunk, 4), false);
+		});
+
+	});
+
+	suite('getHunkOriginalEnd', () => {
+
+		test('should return correct end for deletion hunk', () => {
+			const hunk: DiffHunk = {
+				originalStart: 5,
+				originalLength: 3,
+				modifiedStart: 5,
+				modifiedLength: 2,
+				originalLines: ['a', 'b', 'c'],
+				modifiedLines: ['x', 'y']
+			};
+
+			assert.strictEqual(getHunkOriginalEnd(hunk), 8);
+		});
+
+		test('should return start + 1 for pure insertion hunk', () => {
+			const hunk: DiffHunk = {
+				originalStart: 3,
+				originalLength: 0,
+				modifiedStart: 3,
+				modifiedLength: 2,
+				originalLines: [],
+				modifiedLines: ['new1', 'new2']
+			};
+
+			assert.strictEqual(getHunkOriginalEnd(hunk), 4);
+		});
+
+	});
+
+});

--- a/phpcs-server/test/diff-utils.test.ts
+++ b/phpcs-server/test/diff-utils.test.ts
@@ -111,23 +111,27 @@ suite('Diff Utils', () => {
 		});
 
 		test('should handle empty original content', () => {
+			// Empty content is treated as a single empty line (see computeDiffHunks JSDoc)
 			const original = '';
 			const modified = 'line1\nline2';
 			const hunks = computeDiffHunks(original, modified);
 
 			assert.strictEqual(hunks.length, 1);
-			assert.strictEqual(hunks[0].originalLength, 1); // Empty string splits to ['']
+			assert.strictEqual(hunks[0].originalLength, 1, 'Empty content = 1 empty line');
 			assert.strictEqual(hunks[0].modifiedLength, 2);
+			assert.deepStrictEqual(hunks[0].originalLines, ['']);
 		});
 
 		test('should handle empty modified content', () => {
+			// Empty content is treated as a single empty line (see computeDiffHunks JSDoc)
 			const original = 'line1\nline2';
 			const modified = '';
 			const hunks = computeDiffHunks(original, modified);
 
 			assert.strictEqual(hunks.length, 1);
 			assert.strictEqual(hunks[0].originalLength, 2);
-			assert.strictEqual(hunks[0].modifiedLength, 1); // Empty string splits to ['']
+			assert.strictEqual(hunks[0].modifiedLength, 1, 'Empty content = 1 empty line');
+			assert.deepStrictEqual(hunks[0].modifiedLines, ['']);
 		});
 
 		test('should handle whitespace-only changes', () => {

--- a/phpcs-server/test/fixer.test.ts
+++ b/phpcs-server/test/fixer.test.ts
@@ -51,7 +51,6 @@ suite('PHPCBF Fixer Integration Tests', function () {
 		phpcbfExecutablePath: null,
 		phpcbfOnSave: false,
 		phpcbfSaveOnFix: false,
-		phpcbfShowDiff: false,
 		phpcbfTimeout: 60,
 	};
 

--- a/phpcs-server/test/fixer.test.ts
+++ b/phpcs-server/test/fixer.test.ts
@@ -50,6 +50,7 @@ suite('PHPCBF Fixer Integration Tests', function () {
 		phpcbfEnable: true,
 		phpcbfExecutablePath: null,
 		phpcbfOnSave: false,
+		phpcbfSaveOnFix: false,
 		phpcbfShowDiff: false,
 		phpcbfTimeout: 60,
 	};

--- a/phpcs-server/test/fixer.test.ts
+++ b/phpcs-server/test/fixer.test.ts
@@ -50,6 +50,7 @@ suite('PHPCBF Fixer Integration Tests', function () {
 		phpcbfEnable: true,
 		phpcbfExecutablePath: null,
 		phpcbfOnSave: false,
+		phpcbfShowDiff: false,
 		phpcbfTimeout: 60,
 	};
 

--- a/phpcs-server/test/hunk-correlation.test.ts
+++ b/phpcs-server/test/hunk-correlation.test.ts
@@ -1,0 +1,256 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) John R. D'Orazio. All rights reserved.
+ * Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import * as assert from 'assert';
+import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver/node';
+import { DiffHunk } from '../src/diff-utils';
+import {
+	isDiagnosticInHunk,
+	correlateDiagnosticsToHunks,
+	findHunksForDiagnostic,
+	getDiagnosticsForHunks,
+	isHunkASideEffect
+} from '../src/hunk-correlation';
+
+suite('Hunk Correlation', () => {
+
+	const createDiagnostic = (
+		line: number,
+		character: number = 0,
+		message: string = 'test error'
+	): Diagnostic => ({
+		range: {
+			start: { line, character },
+			end: { line, character: character + 5 }
+		},
+		message,
+		severity: DiagnosticSeverity.Error,
+		source: 'phpcs'
+	});
+
+	const createHunk = (
+		originalStart: number,
+		originalLength: number,
+		modifiedStart: number = originalStart,
+		modifiedLength: number = originalLength
+	): DiffHunk => ({
+		originalStart,
+		originalLength,
+		modifiedStart,
+		modifiedLength,
+		originalLines: Array(originalLength).fill('old'),
+		modifiedLines: Array(modifiedLength).fill('new')
+	});
+
+	suite('isDiagnosticInHunk', () => {
+
+		test('should return true when diagnostic line is at hunk start', () => {
+			const hunk = createHunk(5, 3);
+			const diagnostic = createDiagnostic(5);
+			assert.strictEqual(isDiagnosticInHunk(hunk, diagnostic), true);
+		});
+
+		test('should return true when diagnostic line is within hunk', () => {
+			const hunk = createHunk(5, 3);
+			const diagnostic = createDiagnostic(6);
+			assert.strictEqual(isDiagnosticInHunk(hunk, diagnostic), true);
+		});
+
+		test('should return true when diagnostic line is at hunk end', () => {
+			const hunk = createHunk(5, 3);
+			const diagnostic = createDiagnostic(7);
+			assert.strictEqual(isDiagnosticInHunk(hunk, diagnostic), true);
+		});
+
+		test('should return false when diagnostic line is before hunk', () => {
+			const hunk = createHunk(5, 3);
+			const diagnostic = createDiagnostic(4);
+			assert.strictEqual(isDiagnosticInHunk(hunk, diagnostic), false);
+		});
+
+		test('should return false when diagnostic line is after hunk', () => {
+			const hunk = createHunk(5, 3);
+			const diagnostic = createDiagnostic(8);
+			assert.strictEqual(isDiagnosticInHunk(hunk, diagnostic), false);
+		});
+
+		test('should handle pure insertion hunk', () => {
+			const hunk = createHunk(5, 0, 5, 2);
+			// Pure insertions match the insertion point OR the line before
+			// (e.g., "missing blank line" at line 4 -> insertion at line 5)
+			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(5)), true);
+			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(4)), true); // line before insertion
+			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(3)), false);
+			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(6)), false);
+		});
+
+	});
+
+	suite('correlateDiagnosticsToHunks', () => {
+
+		test('should assign high confidence when single diagnostic matches', () => {
+			const hunks = [createHunk(5, 1)];
+			const diagnostics = [createDiagnostic(5)];
+			const correlations = correlateDiagnosticsToHunks(hunks, diagnostics);
+
+			assert.strictEqual(correlations.length, 1);
+			assert.strictEqual(correlations[0].confidence, 'high');
+			assert.strictEqual(correlations[0].diagnostics.length, 1);
+		});
+
+		test('should assign medium confidence when multiple diagnostics match', () => {
+			const hunks = [createHunk(5, 3)];
+			const diagnostics = [
+				createDiagnostic(5, 0, 'error 1'),
+				createDiagnostic(6, 0, 'error 2')
+			];
+			const correlations = correlateDiagnosticsToHunks(hunks, diagnostics);
+
+			assert.strictEqual(correlations.length, 1);
+			assert.strictEqual(correlations[0].confidence, 'medium');
+			assert.strictEqual(correlations[0].diagnostics.length, 2);
+		});
+
+		test('should assign low confidence when no diagnostics match', () => {
+			const hunks = [createHunk(5, 1)];
+			const diagnostics = [createDiagnostic(10)];
+			const correlations = correlateDiagnosticsToHunks(hunks, diagnostics);
+
+			assert.strictEqual(correlations.length, 1);
+			assert.strictEqual(correlations[0].confidence, 'low');
+			assert.strictEqual(correlations[0].diagnostics.length, 0);
+		});
+
+		test('should handle multiple hunks with mixed confidence', () => {
+			const hunks = [
+				createHunk(1, 1),  // Will have 1 diagnostic (high)
+				createHunk(5, 2),  // Will have 2 diagnostics (medium)
+				createHunk(10, 1)  // Will have 0 diagnostics (low)
+			];
+			const diagnostics = [
+				createDiagnostic(1),
+				createDiagnostic(5),
+				createDiagnostic(6)
+			];
+			const correlations = correlateDiagnosticsToHunks(hunks, diagnostics);
+
+			assert.strictEqual(correlations.length, 3);
+			assert.strictEqual(correlations[0].confidence, 'high');
+			assert.strictEqual(correlations[1].confidence, 'medium');
+			assert.strictEqual(correlations[2].confidence, 'low');
+		});
+
+		test('should return empty correlations for empty hunks', () => {
+			const correlations = correlateDiagnosticsToHunks([], [createDiagnostic(5)]);
+			assert.strictEqual(correlations.length, 0);
+		});
+
+	});
+
+	suite('findHunksForDiagnostic', () => {
+
+		test('should find single hunk containing diagnostic', () => {
+			const hunks = [createHunk(1, 1), createHunk(5, 1), createHunk(10, 1)];
+			const diagnostics = [
+				createDiagnostic(1),
+				createDiagnostic(5),
+				createDiagnostic(10)
+			];
+			const correlations = correlateDiagnosticsToHunks(hunks, diagnostics);
+
+			const result = findHunksForDiagnostic(correlations, diagnostics[1]);
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0].originalStart, 5);
+		});
+
+		test('should return empty array when diagnostic not found', () => {
+			const hunks = [createHunk(1, 1)];
+			const diagnostics = [createDiagnostic(1)];
+			const correlations = correlateDiagnosticsToHunks(hunks, diagnostics);
+
+			const notFoundDiagnostic = createDiagnostic(100);
+			const result = findHunksForDiagnostic(correlations, notFoundDiagnostic);
+			assert.strictEqual(result.length, 0);
+		});
+
+		test('should find hunk when diagnostic matches exactly', () => {
+			const hunks = [createHunk(5, 1)];
+			const diagnostic = createDiagnostic(5, 3, 'specific error');
+			const diagnostics = [diagnostic];
+			const correlations = correlateDiagnosticsToHunks(hunks, diagnostics);
+
+			const result = findHunksForDiagnostic(correlations, diagnostic);
+			assert.strictEqual(result.length, 1);
+		});
+
+	});
+
+	suite('getDiagnosticsForHunks', () => {
+
+		test('should return all diagnostics for specified hunks', () => {
+			const hunks = [createHunk(1, 1), createHunk(5, 2)];
+			const diagnostics = [
+				createDiagnostic(1),
+				createDiagnostic(5),
+				createDiagnostic(6)
+			];
+			const correlations = correlateDiagnosticsToHunks(hunks, diagnostics);
+
+			const result = getDiagnosticsForHunks(correlations, [hunks[1]]);
+			assert.strictEqual(result.length, 2);
+		});
+
+		test('should not include duplicates', () => {
+			const hunks = [createHunk(5, 1)];
+			const diagnostic = createDiagnostic(5);
+			const diagnostics = [diagnostic];
+			const correlations = correlateDiagnosticsToHunks(hunks, diagnostics);
+
+			// Pass the same hunk twice
+			const result = getDiagnosticsForHunks(correlations, [hunks[0], hunks[0]]);
+			assert.strictEqual(result.length, 1);
+		});
+
+		test('should return empty for empty hunks array', () => {
+			const hunks = [createHunk(5, 1)];
+			const diagnostics = [createDiagnostic(5)];
+			const correlations = correlateDiagnosticsToHunks(hunks, diagnostics);
+
+			const result = getDiagnosticsForHunks(correlations, []);
+			assert.strictEqual(result.length, 0);
+		});
+
+	});
+
+	suite('isHunkASideEffect', () => {
+
+		test('should return true for low confidence hunk', () => {
+			const hunks = [createHunk(5, 1)];
+			const diagnostics: Diagnostic[] = []; // No diagnostics for this hunk
+			const correlations = correlateDiagnosticsToHunks(hunks, diagnostics);
+
+			assert.strictEqual(isHunkASideEffect(hunks[0], correlations), true);
+		});
+
+		test('should return false for high confidence hunk', () => {
+			const hunks = [createHunk(5, 1)];
+			const diagnostics = [createDiagnostic(5)];
+			const correlations = correlateDiagnosticsToHunks(hunks, diagnostics);
+
+			assert.strictEqual(isHunkASideEffect(hunks[0], correlations), false);
+		});
+
+		test('should return false for medium confidence hunk', () => {
+			const hunks = [createHunk(5, 2)];
+			const diagnostics = [createDiagnostic(5), createDiagnostic(6)];
+			const correlations = correlateDiagnosticsToHunks(hunks, diagnostics);
+
+			assert.strictEqual(isHunkASideEffect(hunks[0], correlations), false);
+		});
+
+	});
+
+});

--- a/phpcs-server/test/hunk-correlation.test.ts
+++ b/phpcs-server/test/hunk-correlation.test.ts
@@ -131,6 +131,16 @@ suite('Hunk Correlation', () => {
 			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(0)), true);
 		});
 
+		test('should match header diagnostic at line 0 with replacement hunk via header proximity', () => {
+			// Replacement hunk (not pure deletion) at line 3 - still within MAX_HEADER_PROXIMITY
+			// This specifically tests the header proximity branch (lines 94-96)
+			const hunk = createHunk(3, 1, 3, 1); // Replace 1 line at line 3
+			// Diagnostic at line 0 should NOT match via standard case (line 0 not in [3,4))
+			// Diagnostic at line 0 should NOT match via pure deletion proximity (not a pure deletion)
+			// Diagnostic at line 0 SHOULD match via header proximity (hunk at line 3 <= MAX_HEADER_PROXIMITY of 3)
+			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(0)), true);
+		});
+
 		test('should NOT match header diagnostic with hunk beyond header proximity', () => {
 			// Header-related sniffs report at line 0, fix is beyond header proximity
 			const hunk = createHunk(4, 1, 4, 0); // Delete line 4
@@ -251,6 +261,28 @@ suite('Hunk Correlation', () => {
 			assert.strictEqual(result.length, 1);
 		});
 
+		test('should find hunk with lenient matching when useStrictMatching is false', () => {
+			// Pure deletion hunk at line 5 with diagnostic at line 3 (within proximity)
+			const hunks = [createHunk(5, 1, 5, 0)]; // Delete 1 line at line 5
+			const diagnostic = createDiagnostic(3); // 2 lines before hunk (within MAX_DELETION_PROXIMITY)
+			const diagnostics = [diagnostic];
+			const correlations = correlateDiagnosticsToHunks(hunks, diagnostics);
+
+			// Strict mode should NOT find this
+			const strictResult = findHunksForDiagnostic(correlations, diagnostic, true);
+			assert.strictEqual(strictResult.length, 0);
+
+			// Lenient mode should find this
+			const lenientResult = findHunksForDiagnostic(correlations, diagnostic, false);
+			assert.strictEqual(lenientResult.length, 1);
+		});
+
+		test('should handle empty correlations array', () => {
+			const diagnostic = createDiagnostic(5);
+			const result = findHunksForDiagnostic([], diagnostic);
+			assert.strictEqual(result.length, 0);
+		});
+
 	});
 
 	suite('getDiagnosticsForHunks', () => {
@@ -314,6 +346,22 @@ suite('Hunk Correlation', () => {
 			const correlations = correlateDiagnosticsToHunks(hunks, diagnostics);
 
 			assert.strictEqual(isHunkASideEffect(hunks[0], correlations), false);
+		});
+
+		test('should return false when hunk is not found in correlations', () => {
+			// Create correlations for one hunk, but check a different hunk
+			const correlatedHunk = createHunk(5, 1);
+			const diagnostics = [createDiagnostic(5)];
+			const correlations = correlateDiagnosticsToHunks([correlatedHunk], diagnostics);
+
+			// Check a hunk that's not in the correlations
+			const unknownHunk = createHunk(10, 1);
+			assert.strictEqual(isHunkASideEffect(unknownHunk, correlations), false);
+		});
+
+		test('should return false for empty correlations array', () => {
+			const hunk = createHunk(5, 1);
+			assert.strictEqual(isHunkASideEffect(hunk, []), false);
 		});
 
 	});

--- a/phpcs-server/test/hunk-correlation.test.ts
+++ b/phpcs-server/test/hunk-correlation.test.ts
@@ -87,6 +87,71 @@ suite('Hunk Correlation', () => {
 			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(6)), false);
 		});
 
+		test('should handle pure deletion hunk with nearby diagnostic (lenient mode)', () => {
+			// Pure deletion: removes 1 line at line 2, adds 0 lines
+			// (e.g., removing extra blank line between header blocks)
+			const hunk = createHunk(2, 1, 2, 0);
+			// In lenient mode (default), diagnostic at line 0 should match (within proximity of 2 lines)
+			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(0)), true);
+			// Diagnostic at line 1 should also match (1 line before hunk)
+			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(1)), true);
+			// Diagnostic at line 2 (within the hunk) should match
+			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(2)), true);
+			// Diagnostic at line 3 (after hunk) should not match
+			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(3)), false);
+		});
+
+		test('should NOT match pure deletion with distant diagnostic (lenient mode)', () => {
+			// Pure deletion: removes 1 line at line 5, adds 0 lines
+			const hunk = createHunk(5, 1, 5, 0);
+			// Diagnostic at line 0 should NOT match (5 lines before, beyond MAX_DELETION_PROXIMITY of 2)
+			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(0)), false);
+			// Diagnostic at line 2 should NOT match (3 lines before, beyond proximity)
+			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(2)), false);
+			// Diagnostic at line 3 should match (2 lines before, within proximity)
+			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(3)), true);
+		});
+
+		test('should NOT match pure deletion with nearby diagnostic in strict mode', () => {
+			// Pure deletion: removes 1 line at line 2, adds 0 lines
+			const hunk = createHunk(2, 1, 2, 0);
+			// In strict mode, proximity-based matching is disabled
+			// Diagnostic at line 0 should NOT match (not within hunk range)
+			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(0), true), false);
+			// Diagnostic at line 1 should NOT match (not within hunk range)
+			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(1), true), false);
+			// Diagnostic at line 2 (within the hunk) should match
+			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(2), true), true);
+		});
+
+		test('should handle header fix with diagnostic at line 0 (lenient mode)', () => {
+			// Header-related sniffs report at line 0, fix is at nearby line
+			const hunk = createHunk(2, 1, 2, 0); // Delete line 2
+			// Diagnostic at line 0 should match if hunk is within first 3 lines (lenient mode)
+			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(0)), true);
+		});
+
+		test('should NOT match header diagnostic with hunk beyond header proximity', () => {
+			// Header-related sniffs report at line 0, fix is beyond header proximity
+			const hunk = createHunk(4, 1, 4, 0); // Delete line 4
+			// Diagnostic at line 0 should NOT match hunk at line 4 (beyond MAX_HEADER_PROXIMITY of 3)
+			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(0)), false);
+		});
+
+		test('should NOT match header diagnostic with nearby hunk in strict mode', () => {
+			// Header-related sniffs report at line 0, fix is at nearby line
+			const hunk = createHunk(2, 1, 2, 0); // Delete line 2
+			// In strict mode, diagnostic at line 0 should NOT match hunk at line 2
+			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(0), true), false);
+		});
+
+		test('should not match header diagnostic with distant hunk', () => {
+			// Header diagnostic should not match hunk that's too far away
+			const hunk = createHunk(10, 1, 10, 0); // Delete at line 10
+			// Diagnostic at line 0 should NOT match hunk beyond proximity
+			assert.strictEqual(isDiagnosticInHunk(hunk, createDiagnostic(0)), false);
+		});
+
 	});
 
 	suite('correlateDiagnosticsToHunks', () => {

--- a/phpcs-server/test/selective-fix.test.ts
+++ b/phpcs-server/test/selective-fix.test.ts
@@ -18,6 +18,12 @@ import {
 
 suite('Selective Fix', () => {
 
+	/**
+	 * Helper to create a DiffHunk for testing.
+	 * Note: modifiedStart is simplified to equal originalStart since the tested
+	 * functions don't use this field. Default content values ('old'/'new') are
+	 * provided for tests that don't verify actual line content.
+	 */
 	const createHunk = (
 		originalStart: number,
 		originalLength: number,

--- a/phpcs-server/test/selective-fix.test.ts
+++ b/phpcs-server/test/selective-fix.test.ts
@@ -1,0 +1,314 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) John R. D'Orazio. All rights reserved.
+ * Licensed under the MIT License. See License.md in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import * as assert from 'assert';
+import { DiffHunk } from '../src/diff-utils';
+import {
+	applyHunks,
+	sortHunksDescending,
+	hunksOverlap,
+	areHunksIndependent,
+	calculateLineOffset,
+	calculateTotalLineOffset,
+	validateHunks
+} from '../src/selective-fix';
+
+suite('Selective Fix', () => {
+
+	const createHunk = (
+		originalStart: number,
+		originalLength: number,
+		modifiedLength: number,
+		originalLines?: string[],
+		modifiedLines?: string[]
+	): DiffHunk => ({
+		originalStart,
+		originalLength,
+		modifiedStart: originalStart,
+		modifiedLength,
+		originalLines: originalLines || Array(originalLength).fill('old'),
+		modifiedLines: modifiedLines || Array(modifiedLength).fill('new')
+	});
+
+	suite('sortHunksDescending', () => {
+
+		test('should sort hunks by originalStart in descending order', () => {
+			const hunks = [
+				createHunk(1, 1, 1),
+				createHunk(5, 1, 1),
+				createHunk(3, 1, 1)
+			];
+			const sorted = sortHunksDescending(hunks);
+
+			assert.strictEqual(sorted[0].originalStart, 5);
+			assert.strictEqual(sorted[1].originalStart, 3);
+			assert.strictEqual(sorted[2].originalStart, 1);
+		});
+
+		test('should not modify original array', () => {
+			const hunks = [
+				createHunk(1, 1, 1),
+				createHunk(5, 1, 1)
+			];
+			sortHunksDescending(hunks);
+
+			assert.strictEqual(hunks[0].originalStart, 1);
+			assert.strictEqual(hunks[1].originalStart, 5);
+		});
+
+		test('should handle empty array', () => {
+			const sorted = sortHunksDescending([]);
+			assert.strictEqual(sorted.length, 0);
+		});
+
+	});
+
+	suite('applyHunks', () => {
+
+		test('should return original content for empty hunks', () => {
+			const content = 'line1\nline2\nline3';
+			const result = applyHunks(content, []);
+			assert.strictEqual(result, content);
+		});
+
+		test('should apply single line replacement', () => {
+			const content = 'line1\nline2\nline3';
+			const hunk = createHunk(1, 1, 1, ['line2'], ['modified']);
+			const result = applyHunks(content, [hunk]);
+			assert.strictEqual(result, 'line1\nmodified\nline3');
+		});
+
+		test('should apply single line deletion', () => {
+			const content = 'line1\nline2\nline3';
+			const hunk = createHunk(1, 1, 0, ['line2'], []);
+			const result = applyHunks(content, [hunk]);
+			assert.strictEqual(result, 'line1\nline3');
+		});
+
+		test('should apply single line insertion', () => {
+			const content = 'line1\nline3';
+			const hunk = createHunk(1, 0, 1, [], ['line2']);
+			const result = applyHunks(content, [hunk]);
+			assert.strictEqual(result, 'line1\nline2\nline3');
+		});
+
+		test('should apply multiple independent hunks', () => {
+			const content = 'line1\nline2\nline3\nline4\nline5';
+			const hunks = [
+				createHunk(1, 1, 1, ['line2'], ['modified2']),
+				createHunk(3, 1, 1, ['line4'], ['modified4'])
+			];
+			const result = applyHunks(content, hunks);
+			assert.strictEqual(result, 'line1\nmodified2\nline3\nmodified4\nline5');
+		});
+
+		test('should handle hunks in any order (sorts internally)', () => {
+			const content = 'line1\nline2\nline3\nline4\nline5';
+			const hunks = [
+				createHunk(3, 1, 1, ['line4'], ['modified4']),
+				createHunk(1, 1, 1, ['line2'], ['modified2'])
+			];
+			const result = applyHunks(content, hunks);
+			assert.strictEqual(result, 'line1\nmodified2\nline3\nmodified4\nline5');
+		});
+
+		test('should handle multi-line replacement', () => {
+			const content = 'line1\nold1\nold2\nline4';
+			const hunk = createHunk(1, 2, 3, ['old1', 'old2'], ['new1', 'new2', 'new3']);
+			const result = applyHunks(content, [hunk]);
+			assert.strictEqual(result, 'line1\nnew1\nnew2\nnew3\nline4');
+		});
+
+		test('should handle change at start of file', () => {
+			const content = 'line1\nline2\nline3';
+			const hunk = createHunk(0, 1, 1, ['line1'], ['modified1']);
+			const result = applyHunks(content, [hunk]);
+			assert.strictEqual(result, 'modified1\nline2\nline3');
+		});
+
+		test('should handle change at end of file', () => {
+			const content = 'line1\nline2\nline3';
+			const hunk = createHunk(2, 1, 1, ['line3'], ['modified3']);
+			const result = applyHunks(content, [hunk]);
+			assert.strictEqual(result, 'line1\nline2\nmodified3');
+		});
+
+	});
+
+	suite('hunksOverlap', () => {
+
+		test('should return false for non-overlapping hunks', () => {
+			const a = createHunk(1, 2, 2);
+			const b = createHunk(5, 2, 2);
+			assert.strictEqual(hunksOverlap(a, b), false);
+		});
+
+		test('should return true for overlapping hunks', () => {
+			const a = createHunk(1, 3, 3);
+			const b = createHunk(2, 3, 3);
+			assert.strictEqual(hunksOverlap(a, b), true);
+		});
+
+		test('should return false for adjacent hunks', () => {
+			const a = createHunk(1, 2, 2);
+			const b = createHunk(3, 2, 2);
+			assert.strictEqual(hunksOverlap(a, b), false);
+		});
+
+		test('should handle pure insertions at same point', () => {
+			const a = createHunk(5, 0, 1);
+			const b = createHunk(5, 0, 2);
+			assert.strictEqual(hunksOverlap(a, b), true);
+		});
+
+		test('should handle pure insertion within regular hunk', () => {
+			const insertion = createHunk(5, 0, 1);
+			const regular = createHunk(3, 5, 5);
+			assert.strictEqual(hunksOverlap(insertion, regular), true);
+		});
+
+		test('should handle pure insertion outside regular hunk', () => {
+			const insertion = createHunk(10, 0, 1);
+			const regular = createHunk(3, 2, 2);
+			assert.strictEqual(hunksOverlap(insertion, regular), false);
+		});
+
+	});
+
+	suite('areHunksIndependent', () => {
+
+		test('should return true for empty array', () => {
+			assert.strictEqual(areHunksIndependent([]), true);
+		});
+
+		test('should return true for single hunk', () => {
+			assert.strictEqual(areHunksIndependent([createHunk(5, 1, 1)]), true);
+		});
+
+		test('should return true for non-overlapping hunks', () => {
+			const hunks = [
+				createHunk(1, 1, 1),
+				createHunk(5, 1, 1),
+				createHunk(10, 1, 1)
+			];
+			assert.strictEqual(areHunksIndependent(hunks), true);
+		});
+
+		test('should return false for overlapping hunks', () => {
+			const hunks = [
+				createHunk(1, 3, 3),
+				createHunk(2, 2, 2)
+			];
+			assert.strictEqual(areHunksIndependent(hunks), false);
+		});
+
+	});
+
+	suite('calculateLineOffset', () => {
+
+		test('should return 0 for replacement with same line count', () => {
+			const hunk = createHunk(1, 2, 2);
+			assert.strictEqual(calculateLineOffset(hunk), 0);
+		});
+
+		test('should return positive for insertion', () => {
+			const hunk = createHunk(1, 1, 3);
+			assert.strictEqual(calculateLineOffset(hunk), 2);
+		});
+
+		test('should return negative for deletion', () => {
+			const hunk = createHunk(1, 3, 1);
+			assert.strictEqual(calculateLineOffset(hunk), -2);
+		});
+
+		test('should handle pure insertion', () => {
+			const hunk = createHunk(1, 0, 2);
+			assert.strictEqual(calculateLineOffset(hunk), 2);
+		});
+
+		test('should handle pure deletion', () => {
+			const hunk = createHunk(1, 2, 0);
+			assert.strictEqual(calculateLineOffset(hunk), -2);
+		});
+
+	});
+
+	suite('calculateTotalLineOffset', () => {
+
+		test('should return 0 for empty array', () => {
+			assert.strictEqual(calculateTotalLineOffset([]), 0);
+		});
+
+		test('should sum offsets correctly', () => {
+			const hunks = [
+				createHunk(1, 1, 2),  // +1
+				createHunk(5, 2, 1),  // -1
+				createHunk(10, 0, 3)  // +3
+			];
+			assert.strictEqual(calculateTotalLineOffset(hunks), 3);
+		});
+
+	});
+
+	suite('validateHunks', () => {
+
+		test('should return valid for empty hunks', () => {
+			const result = validateHunks('line1\nline2', []);
+			assert.strictEqual(result.valid, true);
+		});
+
+		test('should return invalid for out of bounds start', () => {
+			const content = 'line1\nline2';
+			const hunk = createHunk(10, 1, 1);
+			const result = validateHunks(content, [hunk]);
+			assert.strictEqual(result.valid, false);
+			assert.ok(result.error?.includes('out of bounds'));
+		});
+
+		test('should return invalid for negative start', () => {
+			const content = 'line1\nline2';
+			const hunk = createHunk(-1, 1, 1);
+			const result = validateHunks(content, [hunk]);
+			assert.strictEqual(result.valid, false);
+		});
+
+		test('should return invalid for hunk end exceeding line count', () => {
+			const content = 'line1\nline2';
+			const hunk = createHunk(1, 5, 1);
+			const result = validateHunks(content, [hunk]);
+			assert.strictEqual(result.valid, false);
+			assert.ok(result.error?.includes('exceeds line count'));
+		});
+
+		test('should return invalid for content mismatch', () => {
+			const content = 'line1\nline2\nline3';
+			const hunk = createHunk(1, 1, 1, ['wrong'], ['new']);
+			const result = validateHunks(content, [hunk]);
+			assert.strictEqual(result.valid, false);
+			assert.ok(result.error?.includes('mismatch'));
+		});
+
+		test('should return invalid for overlapping hunks', () => {
+			const content = 'line1\nline2\nline3\nline4\nline5';
+			const hunks = [
+				createHunk(1, 3, 3, ['line2', 'line3', 'line4'], ['a', 'b', 'c']),
+				createHunk(2, 2, 2, ['line3', 'line4'], ['x', 'y'])
+			];
+			const result = validateHunks(content, hunks);
+			assert.strictEqual(result.valid, false);
+			assert.ok(result.error?.includes('overlap'));
+		});
+
+		test('should return valid for correct hunks', () => {
+			const content = 'line1\nline2\nline3';
+			const hunk = createHunk(1, 1, 1, ['line2'], ['modified']);
+			const result = validateHunks(content, [hunk]);
+			assert.strictEqual(result.valid, true);
+		});
+
+	});
+
+});

--- a/phpcs-server/test/selective-fix.test.ts
+++ b/phpcs-server/test/selective-fix.test.ts
@@ -176,6 +176,25 @@ suite('Selective Fix', () => {
 			assert.strictEqual(hunksOverlap(insertion, regular), false);
 		});
 
+		test('should handle regular hunk with pure insertion within (reversed order)', () => {
+			// Test with b as the pure insertion (to cover line 75-77)
+			const regular = createHunk(3, 5, 5);
+			const insertion = createHunk(5, 0, 1);
+			assert.strictEqual(hunksOverlap(regular, insertion), true);
+		});
+
+		test('should handle regular hunk with pure insertion outside (reversed order)', () => {
+			const regular = createHunk(3, 2, 2);
+			const insertion = createHunk(10, 0, 1);
+			assert.strictEqual(hunksOverlap(regular, insertion), false);
+		});
+
+		test('should handle pure insertions at different points', () => {
+			const a = createHunk(5, 0, 1);
+			const b = createHunk(10, 0, 2);
+			assert.strictEqual(hunksOverlap(a, b), false);
+		});
+
 	});
 
 	suite('areHunksIndependent', () => {
@@ -305,6 +324,30 @@ suite('Selective Fix', () => {
 		test('should return valid for correct hunks', () => {
 			const content = 'line1\nline2\nline3';
 			const hunk = createHunk(1, 1, 1, ['line2'], ['modified']);
+			const result = validateHunks(content, [hunk]);
+			assert.strictEqual(result.valid, true);
+		});
+
+		test('should return valid when originalLines is empty (skip content verification)', () => {
+			const content = 'line1\nline2\nline3';
+			// Hunk with originalLength > 0 but empty originalLines array
+			const hunk = createHunk(1, 1, 1, [], ['modified']);
+			const result = validateHunks(content, [hunk]);
+			assert.strictEqual(result.valid, true);
+		});
+
+		test('should return valid for pure insertion hunks', () => {
+			const content = 'line1\nline2\nline3';
+			// Pure insertion: originalLength = 0
+			const hunk = createHunk(1, 0, 1, [], ['inserted']);
+			const result = validateHunks(content, [hunk]);
+			assert.strictEqual(result.valid, true);
+		});
+
+		test('should return valid for hunk at exact end of file', () => {
+			const content = 'line1\nline2\nline3';
+			// Hunk at the last line (index 2, which is valid for 3 lines)
+			const hunk = createHunk(2, 1, 1, ['line3'], ['modified']);
 			const result = validateHunks(content, [hunk]);
 			assert.strictEqual(result.valid, true);
 		});

--- a/phpcs/package.json
+++ b/phpcs/package.json
@@ -199,6 +199,18 @@
 					"default": false,
 					"description": "Automatically fix issues with PHPCBF when saving a file."
 				},
+				"phpcs.phpcbfShowDiff": {
+					"scope": "resource",
+					"type": "boolean",
+					"default": false,
+					"description": "Show a diff preview before applying PHPCBF fixes. When enabled, you can review changes before they are applied."
+				},
+				"phpcs.phpcbfDiffInline": {
+					"scope": "resource",
+					"type": "boolean",
+					"default": false,
+					"description": "Show the diff preview in inline mode instead of side-by-side. Only applies when phpcbfShowDiff is enabled."
+				},
 				"phpcs.phpcbfTimeout": {
 					"scope": "resource",
 					"type": "number",

--- a/phpcs/package.json
+++ b/phpcs/package.json
@@ -205,18 +205,6 @@
 					"default": false,
 					"description": "Automatically save the document after applying PHPCBF fixes. Note: If phpcbfOnSave is also enabled, saving will trigger another PHPCBF run that may fix additional issues."
 				},
-				"phpcs.phpcbfShowDiff": {
-					"scope": "resource",
-					"type": "boolean",
-					"default": false,
-					"description": "Show a diff preview before applying PHPCBF fixes. When enabled, you can review changes before they are applied."
-				},
-				"phpcs.phpcbfDiffInline": {
-					"scope": "resource",
-					"type": "boolean",
-					"default": false,
-					"description": "Show the diff preview in inline mode instead of side-by-side. Only applies when phpcbfShowDiff is enabled."
-				},
 				"phpcs.phpcbfTimeout": {
 					"scope": "resource",
 					"type": "number",

--- a/phpcs/package.json
+++ b/phpcs/package.json
@@ -199,6 +199,12 @@
 					"default": false,
 					"description": "Automatically fix issues with PHPCBF when saving a file."
 				},
+				"phpcs.phpcbfSaveOnFix": {
+					"scope": "resource",
+					"type": "boolean",
+					"default": false,
+					"description": "Automatically save the document after applying PHPCBF fixes. Note: If phpcbfOnSave is also enabled, saving will trigger another PHPCBF run that may fix additional issues."
+				},
 				"phpcs.phpcbfShowDiff": {
 					"scope": "resource",
 					"type": "boolean",

--- a/phpcs/src/configuration.ts
+++ b/phpcs/src/configuration.ts
@@ -103,8 +103,8 @@ export class PhpcsConfiguration extends Disposable {
 				phpcbfEnable: config.get('phpcbfEnable'),
 				phpcbfExecutablePath: config.get('phpcbfExecutablePath'),
 				phpcbfOnSave: config.get('phpcbfOnSave'),
-				phpcbfShowDiff: config.get('phpcbfShowDiff'),
-				phpcbfTimeout: config.get('phpcbfTimeout'),
+				phpcbfShowDiff: config.get('phpcbfShowDiff', false),
+				phpcbfTimeout: config.get('phpcbfTimeout', 60),
 			};
 
 			settings = await this.resolveExecutablePath(settings);

--- a/phpcs/src/configuration.ts
+++ b/phpcs/src/configuration.ts
@@ -103,6 +103,8 @@ export class PhpcsConfiguration extends Disposable {
 				phpcbfEnable: config.get('phpcbfEnable'),
 				phpcbfExecutablePath: config.get('phpcbfExecutablePath'),
 				phpcbfOnSave: config.get('phpcbfOnSave'),
+				phpcbfShowDiff: config.get('phpcbfShowDiff'),
+				phpcbfTimeout: config.get('phpcbfTimeout'),
 			};
 
 			settings = await this.resolveExecutablePath(settings);

--- a/phpcs/src/configuration.ts
+++ b/phpcs/src/configuration.ts
@@ -103,6 +103,7 @@ export class PhpcsConfiguration extends Disposable {
 				phpcbfEnable: config.get('phpcbfEnable'),
 				phpcbfExecutablePath: config.get('phpcbfExecutablePath'),
 				phpcbfOnSave: config.get('phpcbfOnSave'),
+				phpcbfSaveOnFix: config.get('phpcbfSaveOnFix'),
 				phpcbfShowDiff: config.get('phpcbfShowDiff', false),
 				phpcbfTimeout: config.get('phpcbfTimeout', 60),
 			};

--- a/phpcs/src/configuration.ts
+++ b/phpcs/src/configuration.ts
@@ -104,7 +104,6 @@ export class PhpcsConfiguration extends Disposable {
 				phpcbfExecutablePath: config.get('phpcbfExecutablePath'),
 				phpcbfOnSave: config.get('phpcbfOnSave'),
 				phpcbfSaveOnFix: config.get('phpcbfSaveOnFix'),
-				phpcbfShowDiff: config.get('phpcbfShowDiff', false),
 				phpcbfTimeout: config.get('phpcbfTimeout', 60),
 			};
 

--- a/phpcs/src/diff-provider.ts
+++ b/phpcs/src/diff-provider.ts
@@ -59,6 +59,7 @@ export class PhpcbfDiffContentProvider implements TextDocumentContentProvider, D
 	public clearContent(originalUri: string): void {
 		const previewUri = this.createPreviewUri(originalUri);
 		this.contentMap.delete(previewUri.toString());
+		this._onDidChange.fire(previewUri);
 	}
 
 	/**

--- a/phpcs/src/diff-provider.ts
+++ b/phpcs/src/diff-provider.ts
@@ -1,0 +1,81 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) John R. D'Orazio. All rights reserved.
+ * Licensed under the MIT License. See License.md in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+"use strict";
+
+import {
+	TextDocumentContentProvider,
+	Uri,
+	EventEmitter,
+	Event,
+	Disposable
+} from "vscode";
+
+/**
+ * URI scheme for PHPCBF diff preview documents.
+ */
+export const PHPCBF_DIFF_SCHEME = 'phpcbf-preview';
+
+/**
+ * Virtual document content provider for PHPCBF diff previews.
+ * Stores the fixed content in memory and provides it when VS Code requests it.
+ */
+export class PhpcbfDiffContentProvider implements TextDocumentContentProvider, Disposable {
+	private contentMap: Map<string, string> = new Map();
+	private _onDidChange = new EventEmitter<Uri>();
+
+	/**
+	 * Event fired when document content changes.
+	 */
+	public readonly onDidChange: Event<Uri> = this._onDidChange.event;
+
+	/**
+	 * Set the fixed content for a document.
+	 * @param originalUri The original document URI
+	 * @param content The fixed content
+	 * @returns The URI to use for the diff preview
+	 */
+	public setContent(originalUri: string, content: string): Uri {
+		const previewUri = this.createPreviewUri(originalUri);
+		this.contentMap.set(previewUri.toString(), content);
+		this._onDidChange.fire(previewUri);
+		return previewUri;
+	}
+
+	/**
+	 * Provide the content for a virtual document.
+	 * @param uri The URI of the virtual document
+	 * @returns The content of the virtual document
+	 */
+	public provideTextDocumentContent(uri: Uri): string {
+		return this.contentMap.get(uri.toString()) || '';
+	}
+
+	/**
+	 * Clear the content for a document.
+	 * @param originalUri The original document URI
+	 */
+	public clearContent(originalUri: string): void {
+		const previewUri = this.createPreviewUri(originalUri);
+		this.contentMap.delete(previewUri.toString());
+	}
+
+	/**
+	 * Create a preview URI from an original document URI.
+	 * @param originalUri The original document URI
+	 * @returns The preview URI
+	 */
+	private createPreviewUri(originalUri: string): Uri {
+		// Encode the original URI as the path of the preview URI
+		return Uri.parse(`${PHPCBF_DIFF_SCHEME}:${encodeURIComponent(originalUri)}`);
+	}
+
+	/**
+	 * Dispose of resources.
+	 */
+	public dispose(): void {
+		this._onDidChange.dispose();
+		this.contentMap.clear();
+	}
+}

--- a/phpcs/src/extension.ts
+++ b/phpcs/src/extension.ts
@@ -171,7 +171,10 @@ export function activate(context: ExtensionContext) {
 
 			// If hunks are provided, use the per-hunk inline preview
 			if (params.hunks && params.hunks.length > 0 && editor) {
-				const originalContent = editor.document.getText();
+				// Use params.originalContent for hunk application since that's what
+				// the server used to compute the hunks. Using editor.document.getText()
+				// could differ due to timing/sync issues, causing hunks to apply incorrectly.
+				const originalContent = params.originalContent;
 
 				try {
 					// Show per-hunk preview with Accept/Reject for each change

--- a/phpcs/src/extension.ts
+++ b/phpcs/src/extension.ts
@@ -12,9 +12,14 @@ import {
 	commands,
 	ExtensionContext,
 	ProgressLocation,
+	Range,
+	Uri,
 	window,
 	workspace
 } from "vscode";
+
+import { PhpcbfDiffContentProvider, PHPCBF_DIFF_SCHEME } from "./diff-provider";
+import { InlineDiffPreview } from "./inline-diff";
 
 import {
 	ExecuteCommandRequest,
@@ -86,6 +91,17 @@ export function activate(context: ExtensionContext) {
 	// Create the status monitor.
 	let status = new PhpcsStatus();
 
+	// Create and register the diff content provider for PHPCBF preview.
+	const diffProvider = new PhpcbfDiffContentProvider();
+	context.subscriptions.push(
+		workspace.registerTextDocumentContentProvider(PHPCBF_DIFF_SCHEME, diffProvider)
+	);
+	context.subscriptions.push(diffProvider);
+
+	// Create the inline diff preview manager.
+	const inlineDiffPreview = new InlineDiffPreview();
+	context.subscriptions.push(inlineDiffPreview);
+
 	// Track whether the client has started successfully
 	let clientStarted = false;
 
@@ -99,6 +115,102 @@ export function activate(context: ExtensionContext) {
 		client.onNotification(proto.DidEndValidateTextDocumentNotification.type, event => {
 			status.endProcessing(event.textDocument.uri, event.buffered);
 		});
+		client.onNotification(proto.DidStartFixTextDocumentNotification.type, event => {
+			status.startFixing(event.textDocument.uri);
+		});
+		client.onNotification(proto.DidEndFixTextDocumentNotification.type, event => {
+			status.endFixing(event.textDocument.uri, event.fixed);
+		});
+
+		// Handle diff preview request from server
+		client.onRequest(proto.ShowDiffPreviewRequest.type, async (params) => {
+			const originalUri = Uri.parse(params.uri);
+
+			// Check if inline diff is preferred
+			const phpcsConfig = workspace.getConfiguration('phpcs');
+			const useInlineDiff = phpcsConfig.get<boolean>('phpcbfDiffInline', false);
+
+			if (useInlineDiff) {
+				// Use inline decorations in the current editor
+				const editor = window.visibleTextEditors.find(
+					e => e.document.uri.toString() === originalUri.toString()
+				);
+
+				if (!editor) {
+					// Fallback to diff editor if can't find the editor
+					return showDiffEditor(originalUri, params, diffProvider);
+				}
+
+				// Store original content before applying fixes
+				const originalContent = editor.document.getText();
+
+				try {
+					// Apply the fixed content temporarily
+					const fullRange = editor.document.validateRange(
+						new Range(0, 0, editor.document.lineCount, 0)
+					);
+					await editor.edit(editBuilder => {
+						editBuilder.replace(fullRange, params.fixedContent);
+					});
+
+					// Show decorations and CodeLens, wait for user decision
+					const accepted = await inlineDiffPreview.showPreviewAndWait(
+						editor,
+						originalContent,
+						params.fixedContent
+					);
+
+					if (!accepted) {
+						// Restore original content
+						const currentRange = editor.document.validateRange(
+							new Range(0, 0, editor.document.lineCount, 0)
+						);
+						await editor.edit(editBuilder => {
+							editBuilder.replace(currentRange, originalContent);
+						});
+						return false;
+					}
+
+					return true;
+				} finally {
+					// Clear decorations and CodeLens
+					inlineDiffPreview.clearPreview();
+				}
+			} else {
+				// Use separate diff editor
+				return showDiffEditor(originalUri, params, diffProvider);
+			}
+		});
+
+		// Helper function for diff editor approach
+		async function showDiffEditor(
+			originalUri: Uri,
+			params: proto.ShowDiffPreviewParams,
+			provider: PhpcbfDiffContentProvider
+		): Promise<boolean> {
+			const previewUri = provider.setContent(params.uri, params.fixedContent);
+
+			try {
+				// Show diff editor
+				await commands.executeCommand(
+					'vscode.diff',
+					originalUri,
+					previewUri,
+					`PHPCBF Preview: ${path.basename(originalUri.fsPath)}`
+				);
+
+				// Ask user to apply changes
+				const apply = await window.showInformationMessage(
+					SR.PhpcbfDiffApplyQuestion,
+					SR.PhpcbfDiffApply,
+					SR.PhpcbfDiffCancel
+				);
+
+				return apply === SR.PhpcbfDiffApply;
+			} finally {
+				provider.clearContent(params.uri);
+			}
+		}
 
 		/**
 		 * Command handler for fixing the current file with PHPCBF.

--- a/phpcs/src/extension.ts
+++ b/phpcs/src/extension.ts
@@ -19,7 +19,7 @@ import {
 } from "vscode";
 
 import { PhpcbfDiffContentProvider, PHPCBF_DIFF_SCHEME } from "./diff-provider";
-import { InlineDiffPreview } from "./inline-diff";
+import { InlineDiffPreview, applySelectedHunks } from "./inline-diff";
 
 import {
 	ExecuteCommandRequest,
@@ -124,16 +124,42 @@ export function activate(context: ExtensionContext) {
 
 		// Handle save document notification from server
 		client.onNotification(proto.SaveDocumentNotification.type, async (params) => {
+			console.log('[PHPCS] SaveDocumentNotification received for:', params.uri);
+
 			const phpcsConfig = workspace.getConfiguration('phpcs');
 			const saveOnFix = phpcsConfig.get<boolean>('phpcbfSaveOnFix', false);
+			console.log('[PHPCS] phpcbfSaveOnFix setting:', saveOnFix);
 
 			if (saveOnFix) {
 				const documentUri = Uri.parse(params.uri);
-				const document = workspace.textDocuments.find(
-					doc => doc.uri.toString() === documentUri.toString()
-				);
-				if (document && document.isDirty) {
-					await document.save();
+
+				// Small delay to ensure workspace edit has been fully applied
+				await new Promise(resolve => setTimeout(resolve, 100));
+
+				// Try to find the document - first check active editor, then open documents
+				let document = window.activeTextEditor?.document;
+				console.log('[PHPCS] Active editor document:', window.activeTextEditor?.document.uri.toString());
+
+				if (!document || document.uri.toString() !== documentUri.toString()) {
+					document = workspace.textDocuments.find(
+						doc => doc.uri.toString() === documentUri.toString()
+					);
+					console.log('[PHPCS] Found document in workspace:', document?.uri.toString());
+				}
+
+				if (document) {
+					console.log('[PHPCS] Document isDirty:', document.isDirty);
+					if (document.isDirty) {
+						const saved = await document.save();
+						console.log('[PHPCS] Save result:', saved);
+						if (!saved) {
+							console.warn('PHPCS: Failed to save document after fix');
+						}
+					} else {
+						console.log('[PHPCS] Document not dirty, skipping save');
+					}
+				} else {
+					console.warn('[PHPCS] Could not find document to save');
 				}
 			}
 		});
@@ -141,87 +167,72 @@ export function activate(context: ExtensionContext) {
 		// Handle diff preview request from server
 		client.onRequest(proto.ShowDiffPreviewRequest.type, async (params) => {
 			const originalUri = Uri.parse(params.uri);
-
-			// Check if inline diff is preferred
 			const phpcsConfig = workspace.getConfiguration('phpcs');
-			const useInlineDiff = phpcsConfig.get<boolean>('phpcbfDiffInline', false);
 
-			if (useInlineDiff) {
-				// Use inline decorations in the current editor
-				const editor = window.visibleTextEditors.find(
-					e => e.document.uri.toString() === originalUri.toString()
-				);
+			// Find the editor for this document
+			const editor = window.visibleTextEditors.find(
+				e => e.document.uri.toString() === originalUri.toString()
+			);
 
-				if (!editor) {
-					// Fallback to diff editor if can't find the editor
-					return showDiffEditor(originalUri, params, diffProvider);
-				}
-
-				// Store original content before applying fixes
+			// If hunks are provided, use the per-hunk inline preview
+			if (params.hunks && params.hunks.length > 0 && editor) {
 				const originalContent = editor.document.getText();
 
 				try {
-					// Apply the fixed content temporarily
+					// Show per-hunk preview with Accept/Reject for each change
+					const acceptedHunks = await inlineDiffPreview.showHunkPreview(
+						editor,
+						originalContent,
+						params.hunks
+					);
+
+					if (acceptedHunks.length === 0) {
+						// User cancelled or rejected all
+						return false;
+					}
+
+					// Apply only the accepted hunks
+					const partiallyFixedContent = applySelectedHunks(originalContent, acceptedHunks);
+
+					// Apply the changes to the document
 					const fullRange = editor.document.validateRange(
 						new Range(0, 0, editor.document.lineCount, 0)
 					);
 					const applied = await editor.edit(editBuilder => {
-						editBuilder.replace(fullRange, params.fixedContent);
+						editBuilder.replace(fullRange, partiallyFixedContent);
 					});
 
 					if (!applied) {
-						// Fallback to diff editor if edit failed
-						return showDiffEditor(originalUri, params, diffProvider);
-					}
-
-					// Track document version after applying fix to detect concurrent edits
-					const versionAfterFix = editor.document.version;
-
-					// Show decorations and CodeLens, wait for user decision
-					const accepted = await inlineDiffPreview.showPreviewAndWait(
-						editor,
-						originalContent,
-						params.fixedContent,
-						params.targetLine
-					);
-
-					if (!accepted) {
-						// Check if document was modified during preview
-						if (editor.document.version !== versionAfterFix) {
-							window.showWarningMessage(
-								'Document was modified during preview. Original content was not restored.'
-							);
-							return false;
-						}
-
-						// Restore original content
-						const currentRange = editor.document.validateRange(
-							new Range(0, 0, editor.document.lineCount, 0)
-						);
-						const restored = await editor.edit(editBuilder => {
-							editBuilder.replace(currentRange, originalContent);
-						});
-						if (!restored) {
-							window.showErrorMessage('Failed to restore original content');
-						}
+						window.showErrorMessage('Failed to apply selected changes');
 						return false;
 					}
 
 					// Save document if setting is enabled
+					// Note: We handle save here on the client side since we have direct access
+					// to the editor. The server also sends SaveDocumentNotification but that
+					// serves as a fallback.
 					const saveOnFix = phpcsConfig.get<boolean>('phpcbfSaveOnFix', false);
-					if (saveOnFix) {
-						await editor.document.save();
+					if (saveOnFix && editor.document.isDirty) {
+						// Small delay to ensure the edit has been fully applied
+						await new Promise(resolve => setTimeout(resolve, 50));
+						const saved = await editor.document.save();
+						if (!saved) {
+							console.warn('PHPCS: Failed to save document after applying fix');
+						}
 					}
 
+					window.showInformationMessage(
+						`Applied ${acceptedHunks.length} of ${params.hunks.length} change(s)`
+					);
 					return true;
 				} finally {
 					// Clear decorations and CodeLens
 					inlineDiffPreview.clearPreview();
 				}
-			} else {
-				// Use separate diff editor
-				return showDiffEditor(originalUri, params, diffProvider);
 			}
+
+			// Fallback: no hunks provided or no editor - use diff editor
+			return showDiffEditor(originalUri, params, diffProvider);
 		});
 
 		// Helper function for diff editor approach

--- a/phpcs/src/extension.ts
+++ b/phpcs/src/extension.ts
@@ -37,6 +37,24 @@ import { PhpcsConfiguration } from "./configuration";
 import { StringResources as SR, format } from "./strings";
 
 /**
+ * Save document if phpcbfSaveOnFix setting is enabled and document is dirty.
+ *
+ * @param document - The document to save
+ * @returns True if saved successfully or save not needed, false if save failed
+ */
+async function saveDocumentIfEnabled(document: { isDirty: boolean; save: () => Thenable<boolean> }): Promise<boolean> {
+	const phpcsConfig = workspace.getConfiguration('phpcs');
+	const saveOnFix = phpcsConfig.get<boolean>('phpcbfSaveOnFix', false);
+
+	if (saveOnFix && document.isDirty) {
+		// Small delay to ensure any pending edits have been fully applied
+		await new Promise(resolve => setTimeout(resolve, 50));
+		return document.save();
+	}
+	return true;
+}
+
+/**
  * Activates the extension: starts and configures the PHPCS language client, registers notifications and disposables.
  *
  * @param context - VS Code extension context used to register subscriptions and resolve extension paths
@@ -124,42 +142,20 @@ export function activate(context: ExtensionContext) {
 
 		// Handle save document notification from server
 		client.onNotification(proto.SaveDocumentNotification.type, async (params) => {
-			console.log('[PHPCS] SaveDocumentNotification received for:', params.uri);
+			const documentUri = Uri.parse(params.uri);
 
-			const phpcsConfig = workspace.getConfiguration('phpcs');
-			const saveOnFix = phpcsConfig.get<boolean>('phpcbfSaveOnFix', false);
-			console.log('[PHPCS] phpcbfSaveOnFix setting:', saveOnFix);
+			// Try to find the document - first check active editor, then open documents
+			let document = window.activeTextEditor?.document;
+			if (!document || document.uri.toString() !== documentUri.toString()) {
+				document = workspace.textDocuments.find(
+					doc => doc.uri.toString() === documentUri.toString()
+				);
+			}
 
-			if (saveOnFix) {
-				const documentUri = Uri.parse(params.uri);
-
-				// Small delay to ensure workspace edit has been fully applied
-				await new Promise(resolve => setTimeout(resolve, 100));
-
-				// Try to find the document - first check active editor, then open documents
-				let document = window.activeTextEditor?.document;
-				console.log('[PHPCS] Active editor document:', window.activeTextEditor?.document.uri.toString());
-
-				if (!document || document.uri.toString() !== documentUri.toString()) {
-					document = workspace.textDocuments.find(
-						doc => doc.uri.toString() === documentUri.toString()
-					);
-					console.log('[PHPCS] Found document in workspace:', document?.uri.toString());
-				}
-
-				if (document) {
-					console.log('[PHPCS] Document isDirty:', document.isDirty);
-					if (document.isDirty) {
-						const saved = await document.save();
-						console.log('[PHPCS] Save result:', saved);
-						if (!saved) {
-							console.warn('PHPCS: Failed to save document after fix');
-						}
-					} else {
-						console.log('[PHPCS] Document not dirty, skipping save');
-					}
-				} else {
-					console.warn('[PHPCS] Could not find document to save');
+			if (document) {
+				const saved = await saveDocumentIfEnabled(document);
+				if (!saved) {
+					console.warn('PHPCS: Failed to save document after fix');
 				}
 			}
 		});
@@ -167,7 +163,6 @@ export function activate(context: ExtensionContext) {
 		// Handle diff preview request from server
 		client.onRequest(proto.ShowDiffPreviewRequest.type, async (params) => {
 			const originalUri = Uri.parse(params.uri);
-			const phpcsConfig = workspace.getConfiguration('phpcs');
 
 			// Find the editor for this document
 			const editor = window.visibleTextEditors.find(
@@ -208,17 +203,9 @@ export function activate(context: ExtensionContext) {
 					}
 
 					// Save document if setting is enabled
-					// Note: We handle save here on the client side since we have direct access
-					// to the editor. The server also sends SaveDocumentNotification but that
-					// serves as a fallback.
-					const saveOnFix = phpcsConfig.get<boolean>('phpcbfSaveOnFix', false);
-					if (saveOnFix && editor.document.isDirty) {
-						// Small delay to ensure the edit has been fully applied
-						await new Promise(resolve => setTimeout(resolve, 50));
-						const saved = await editor.document.save();
-						if (!saved) {
-							console.warn('PHPCS: Failed to save document after applying fix');
-						}
+					const saved = await saveDocumentIfEnabled(editor.document);
+					if (!saved) {
+						console.warn('PHPCS: Failed to save document after applying fix');
 					}
 
 					window.showInformationMessage(

--- a/phpcs/src/extension.ts
+++ b/phpcs/src/extension.ts
@@ -47,7 +47,11 @@ async function saveDocumentIfEnabled(document: { isDirty: boolean; save: () => T
 	const saveOnFix = phpcsConfig.get<boolean>('phpcbfSaveOnFix', false);
 
 	if (saveOnFix && document.isDirty) {
-		// Small delay to ensure any pending edits have been fully applied
+		// Small delay to ensure any pending edits have been fully applied.
+		// This is a timing-based buffer that works reliably in practice, though
+		// theoretically could be insufficient under extreme system load. A more
+		// robust approach would use document change events, but adds complexity
+		// for an edge case that hasn't been observed in real usage.
 		await new Promise(resolve => setTimeout(resolve, 50));
 		return document.save();
 	}

--- a/phpcs/src/extension.ts
+++ b/phpcs/src/extension.ts
@@ -47,12 +47,6 @@ async function saveDocumentIfEnabled(document: { isDirty: boolean; save: () => T
 	const saveOnFix = phpcsConfig.get<boolean>('phpcbfSaveOnFix', false);
 
 	if (saveOnFix && document.isDirty) {
-		// Small delay to ensure any pending edits have been fully applied.
-		// This is a timing-based buffer that works reliably in practice, though
-		// theoretically could be insufficient under extreme system load. A more
-		// robust approach would use document change events, but adds complexity
-		// for an edge case that hasn't been observed in real usage.
-		await new Promise(resolve => setTimeout(resolve, 50));
 		return document.save();
 	}
 	return true;

--- a/phpcs/src/extension.ts
+++ b/phpcs/src/extension.ts
@@ -122,6 +122,22 @@ export function activate(context: ExtensionContext) {
 			status.endFixing(event.textDocument.uri, event.fixed);
 		});
 
+		// Handle save document notification from server
+		client.onNotification(proto.SaveDocumentNotification.type, async (params) => {
+			const phpcsConfig = workspace.getConfiguration('phpcs');
+			const saveOnFix = phpcsConfig.get<boolean>('phpcbfSaveOnFix', false);
+
+			if (saveOnFix) {
+				const documentUri = Uri.parse(params.uri);
+				const document = workspace.textDocuments.find(
+					doc => doc.uri.toString() === documentUri.toString()
+				);
+				if (document && document.isDirty) {
+					await document.save();
+				}
+			}
+		});
+
 		// Handle diff preview request from server
 		client.onRequest(proto.ShowDiffPreviewRequest.type, async (params) => {
 			const originalUri = Uri.parse(params.uri);
@@ -165,7 +181,8 @@ export function activate(context: ExtensionContext) {
 					const accepted = await inlineDiffPreview.showPreviewAndWait(
 						editor,
 						originalContent,
-						params.fixedContent
+						params.fixedContent,
+						params.targetLine
 					);
 
 					if (!accepted) {
@@ -188,6 +205,12 @@ export function activate(context: ExtensionContext) {
 							window.showErrorMessage('Failed to restore original content');
 						}
 						return false;
+					}
+
+					// Save document if setting is enabled
+					const saveOnFix = phpcsConfig.get<boolean>('phpcbfSaveOnFix', false);
+					if (saveOnFix) {
+						await editor.document.save();
 					}
 
 					return true;

--- a/phpcs/src/extension.ts
+++ b/phpcs/src/extension.ts
@@ -149,9 +149,17 @@ export function activate(context: ExtensionContext) {
 					const fullRange = editor.document.validateRange(
 						new Range(0, 0, editor.document.lineCount, 0)
 					);
-					await editor.edit(editBuilder => {
+					const applied = await editor.edit(editBuilder => {
 						editBuilder.replace(fullRange, params.fixedContent);
 					});
+
+					if (!applied) {
+						// Fallback to diff editor if edit failed
+						return showDiffEditor(originalUri, params, diffProvider);
+					}
+
+					// Track document version after applying fix to detect concurrent edits
+					const versionAfterFix = editor.document.version;
 
 					// Show decorations and CodeLens, wait for user decision
 					const accepted = await inlineDiffPreview.showPreviewAndWait(
@@ -161,13 +169,24 @@ export function activate(context: ExtensionContext) {
 					);
 
 					if (!accepted) {
+						// Check if document was modified during preview
+						if (editor.document.version !== versionAfterFix) {
+							window.showWarningMessage(
+								'Document was modified during preview. Original content was not restored.'
+							);
+							return false;
+						}
+
 						// Restore original content
 						const currentRange = editor.document.validateRange(
 							new Range(0, 0, editor.document.lineCount, 0)
 						);
-						await editor.edit(editBuilder => {
+						const restored = await editor.edit(editBuilder => {
 							editBuilder.replace(currentRange, originalContent);
 						});
+						if (!restored) {
+							window.showErrorMessage('Failed to restore original content');
+						}
 						return false;
 					}
 

--- a/phpcs/src/inline-diff.ts
+++ b/phpcs/src/inline-diff.ts
@@ -126,10 +126,16 @@ function computeLCS(a: string[], b: string[]): string[] {
 class DiffActionCodeLensProvider implements CodeLensProvider {
 	private documentUri: string | null = null;
 	private stats: { additions: number; deletions: number } = { additions: 0, deletions: 0 };
+	private targetLine: number = 0;
 
-	public setActiveDocument(uri: string, stats: { additions: number; deletions: number }): void {
+	public setActiveDocument(
+		uri: string,
+		stats: { additions: number; deletions: number },
+		targetLine?: number
+	): void {
 		this.documentUri = uri;
 		this.stats = stats;
+		this.targetLine = targetLine ?? 0;
 	}
 
 	public clearActiveDocument(): void {
@@ -141,7 +147,9 @@ class DiffActionCodeLensProvider implements CodeLensProvider {
 			return [];
 		}
 
-		const range = new Range(0, 0, 0, 0);
+		// Position CodeLens at the target line (or line before it for visibility)
+		const line = Math.max(0, this.targetLine);
+		const range = new Range(line, 0, line, 0);
 
 		const applyCommand: Command = {
 			title: '✓ Apply Changes',
@@ -293,12 +301,14 @@ export class InlineDiffPreview implements Disposable {
 	 * @param editor The text editor
 	 * @param originalContent The original file content
 	 * @param fixedContent The fixed content from PHPCBF
+	 * @param targetLine Optional line number for positioning the CodeLens (0-indexed)
 	 * @returns Promise that resolves to true if user accepts, false if cancels
 	 */
 	public async showPreviewAndWait(
 		editor: TextEditor,
 		originalContent: string,
-		fixedContent: string
+		fixedContent: string,
+		targetLine?: number
 	): Promise<boolean> {
 		// Clear any existing preview state to prevent race conditions
 		if (this.pendingResolve) {
@@ -317,7 +327,7 @@ export class InlineDiffPreview implements Disposable {
 		);
 
 		// Register CodeLens provider and commands
-		this.codeLensProvider.setActiveDocument(editor.document.uri.toString(), { additions, deletions });
+		this.codeLensProvider.setActiveDocument(editor.document.uri.toString(), { additions, deletions }, targetLine);
 
 		// Register commands for accept/cancel
 		this.applyCommandRegistration = commands.registerCommand('phpcs.inlineDiffApply', () => {

--- a/phpcs/src/inline-diff.ts
+++ b/phpcs/src/inline-diff.ts
@@ -2,7 +2,7 @@
  * Copyright (c) John R. D'Orazio. All rights reserved.
  * Licensed under the MIT License. See License.md in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
-"use strict";
+'use strict';
 
 import {
 	window,
@@ -21,9 +21,9 @@ import {
 	commands,
 	EventEmitter,
 	Event
-} from "vscode";
+} from 'vscode';
 
-import { PreviewDiffHunk } from "./protocol";
+import { PreviewDiffHunk } from './protocol';
 
 /**
  * Tracked hunk for preview.

--- a/phpcs/src/inline-diff.ts
+++ b/phpcs/src/inline-diff.ts
@@ -160,9 +160,17 @@ export class InlineDiffPreview implements Disposable {
 			}
 		});
 
-		// Green background for showing replacement content inline
+		// Green background for showing where additional lines will be added
 		this.additionDecorationType = window.createTextEditorDecorationType({
+			backgroundColor: 'rgba(0, 200, 0, 0.1)',
 			isWholeLine: true,
+			overviewRulerColor: new ThemeColor('editorOverviewRuler.addedForeground'),
+			overviewRulerLane: 1,
+			before: {
+				contentText: '+',
+				color: 'rgba(0, 200, 0, 0.6)',
+				margin: '0 8px 0 0'
+			}
 		});
 
 		// Green background for pure insertions (shown as a decoration on adjacent line)
@@ -221,6 +229,31 @@ export class InlineDiffPreview implements Disposable {
 						}
 					}
 				});
+
+				// If adding more lines than removing, show indicator on next line
+				const extraLines = hunk.modifiedLength - hunk.originalLength;
+				if (extraLines > 0) {
+					const nextLine = safeEndLine + 1;
+					if (nextLine < this.activeEditor.document.lineCount) {
+						const nextLineText = this.activeEditor.document.lineAt(nextLine).text;
+						const addRange = new Range(
+							new Position(nextLine, 0),
+							new Position(nextLine, nextLineText.length)
+						);
+						additionDecorations.push({
+							range: addRange,
+							hoverMessage: `**${extraLines} line(s) will be added above**`,
+							renderOptions: {
+								after: {
+									contentText: ` ↑ ${extraLines} line(s) added`,
+									color: 'rgba(0, 180, 0, 0.9)',
+									fontStyle: 'italic',
+									margin: '0 0 0 1em'
+								}
+							}
+						});
+					}
+				}
 			} else if (hunk.originalLength > 0) {
 				// Pure deletion
 				const range = new Range(

--- a/phpcs/src/inline-diff.ts
+++ b/phpcs/src/inline-diff.ts
@@ -296,10 +296,10 @@ export class InlineDiffPreview implements Disposable {
 							this.pendingResolve([]);
 							this.pendingResolve = null;
 						}
-					} else {
-						// Update display
+					} else if (this.activeEditor) {
+						// Update display only if editor is still active
 						this.codeLensProvider.setHunks(
-							this.activeEditor!.document.uri.toString(),
+							this.activeEditor.document.uri.toString(),
 							this.trackedHunks
 						);
 						this.updateDecorations();

--- a/phpcs/src/inline-diff.ts
+++ b/phpcs/src/inline-diff.ts
@@ -312,10 +312,22 @@ export class InlineDiffPreview implements Disposable {
 			commands.registerCommand('phpcs.hunkAccept', (index: number) => {
 				if (this.pendingResolve && index >= 0 && index < this.trackedHunks.length) {
 					const hunk = this.trackedHunks[index].hunk;
-					// Clear decorations immediately before resolving
+					const resolve = this.pendingResolve;
+
+					// Clear all state immediately to prevent stale data issues
 					this.clearDecorations();
-					this.pendingResolve([hunk]);
+					this.trackedHunks = [];
 					this.pendingResolve = null;
+					this.activeEditor = null;
+
+					// Dispose CodeLens registration to prevent refresh issues
+					if (this.codeLensRegistration) {
+						this.codeLensRegistration.dispose();
+						this.codeLensRegistration = null;
+					}
+
+					// Now resolve - this triggers the edit in extension.ts
+					resolve([hunk]);
 				}
 			})
 		);
@@ -352,10 +364,22 @@ export class InlineDiffPreview implements Disposable {
 			commands.registerCommand('phpcs.hunkAcceptAll', () => {
 				if (this.pendingResolve) {
 					const allHunks = this.trackedHunks.map(t => t.hunk);
-					// Clear decorations immediately before resolving
+					const resolve = this.pendingResolve;
+
+					// Clear all state immediately to prevent stale data issues
 					this.clearDecorations();
-					this.pendingResolve(allHunks);
+					this.trackedHunks = [];
 					this.pendingResolve = null;
+					this.activeEditor = null;
+
+					// Dispose CodeLens registration to prevent refresh issues
+					if (this.codeLensRegistration) {
+						this.codeLensRegistration.dispose();
+						this.codeLensRegistration = null;
+					}
+
+					// Now resolve - this triggers the edit in extension.ts
+					resolve(allHunks);
 				}
 			})
 		);
@@ -364,8 +388,21 @@ export class InlineDiffPreview implements Disposable {
 		this.commandRegistrations.push(
 			commands.registerCommand('phpcs.hunkCancel', () => {
 				if (this.pendingResolve) {
-					this.pendingResolve([]);
+					const resolve = this.pendingResolve;
+
+					// Clear all state immediately
+					this.clearDecorations();
+					this.trackedHunks = [];
 					this.pendingResolve = null;
+					this.activeEditor = null;
+
+					// Dispose CodeLens registration
+					if (this.codeLensRegistration) {
+						this.codeLensRegistration.dispose();
+						this.codeLensRegistration = null;
+					}
+
+					resolve([]);
 				}
 			})
 		);
@@ -470,6 +507,10 @@ export class InlineDiffPreview implements Disposable {
 			this.activeEditor.setDecorations(this.insertionDecorationType, []);
 		}
 		this.codeLensProvider.clear();
+
+		// Force VS Code to repaint the editor to ensure decorations are visually cleared
+		// This works around a VS Code rendering issue where decorations may persist visually
+		commands.executeCommand('editor.action.forceRetokenize');
 	}
 
 	/**

--- a/phpcs/src/inline-diff.ts
+++ b/phpcs/src/inline-diff.ts
@@ -186,6 +186,7 @@ export class InlineDiffPreview implements Disposable {
 	private applyCommandRegistration: Disposable | null = null;
 	private cancelCommandRegistration: Disposable | null = null;
 	private pendingResolve: ((value: boolean) => void) | null = null;
+	private timeoutId: ReturnType<typeof setTimeout> | null = null;
 
 	constructor() {
 		// Green background for additions
@@ -217,29 +218,24 @@ export class InlineDiffPreview implements Disposable {
 	}
 
 	/**
-	 * Show inline diff preview in the editor and wait for user decision.
+	 * Compute diff and apply decorations to the editor.
 	 * @param editor The text editor
 	 * @param originalContent The original file content
 	 * @param fixedContent The fixed content from PHPCBF
-	 * @returns Promise that resolves to true if user accepts, false if cancels
+	 * @returns Object with line counts and decorations applied
 	 */
-	public async showPreviewAndWait(
+	private computeAndApplyDecorations(
 		editor: TextEditor,
 		originalContent: string,
 		fixedContent: string
-	): Promise<boolean> {
-		this.activeEditor = editor;
+	): { additions: number; deletions: number } {
 		this.deletedLinesContent.clear();
-
 		const changes = computeLineDiff(originalContent, fixedContent);
-
 		const additionDecorations: DecorationOptions[] = [];
 
 		let additions = 0;
 		let deletions = 0;
 
-		// We need to show the preview on the FIXED content
-		// So we'll track which lines in the fixed content are new
 		const fixedLines = fixedContent.split('\n');
 
 		for (const change of changes) {
@@ -257,14 +253,68 @@ export class InlineDiffPreview implements Disposable {
 				}
 			} else if (change.type === 'delete') {
 				deletions++;
-				// For deletions, we'll show them at the corresponding position
-				// Since the line won't exist in the preview, we show at nearest line
 				this.deletedLinesContent.set(change.lineNumber, change.oldText || '');
 			}
 		}
 
-		// Apply decorations for additions
 		editor.setDecorations(this.additionDecorationType, additionDecorations);
+
+		return { additions, deletions };
+	}
+
+	/**
+	 * Clean up CodeLens registrations and pending state.
+	 */
+	private cleanupCodeLens(): void {
+		// Clear timeout if active
+		if (this.timeoutId) {
+			clearTimeout(this.timeoutId);
+			this.timeoutId = null;
+		}
+
+		// Cleanup CodeLens provider
+		this.codeLensProvider.clearActiveDocument();
+		if (this.codeLensRegistration) {
+			this.codeLensRegistration.dispose();
+			this.codeLensRegistration = null;
+		}
+		if (this.applyCommandRegistration) {
+			this.applyCommandRegistration.dispose();
+			this.applyCommandRegistration = null;
+		}
+		if (this.cancelCommandRegistration) {
+			this.cancelCommandRegistration.dispose();
+			this.cancelCommandRegistration = null;
+		}
+	}
+
+	/**
+	 * Show inline diff preview in the editor and wait for user decision.
+	 * @param editor The text editor
+	 * @param originalContent The original file content
+	 * @param fixedContent The fixed content from PHPCBF
+	 * @returns Promise that resolves to true if user accepts, false if cancels
+	 */
+	public async showPreviewAndWait(
+		editor: TextEditor,
+		originalContent: string,
+		fixedContent: string
+	): Promise<boolean> {
+		// Clear any existing preview state to prevent race conditions
+		if (this.pendingResolve) {
+			this.pendingResolve(false);
+			this.pendingResolve = null;
+		}
+		this.cleanupCodeLens();
+
+		this.activeEditor = editor;
+
+		// Compute and apply decorations
+		const { additions, deletions } = this.computeAndApplyDecorations(
+			editor,
+			originalContent,
+			fixedContent
+		);
 
 		// Register CodeLens provider and commands
 		this.codeLensProvider.setActiveDocument(editor.document.uri.toString(), { additions, deletions });
@@ -290,14 +340,29 @@ export class InlineDiffPreview implements Disposable {
 			this.codeLensProvider
 		);
 
-		// Wait for user decision
+		// Wait for user decision with timeout (5 minutes)
+		const timeoutMs = 300000;
+
 		return new Promise<boolean>((resolve) => {
-			this.pendingResolve = resolve;
+			this.pendingResolve = (value: boolean) => {
+				if (this.timeoutId) {
+					clearTimeout(this.timeoutId);
+					this.timeoutId = null;
+				}
+				resolve(value);
+			};
+
+			this.timeoutId = setTimeout(() => {
+				if (this.pendingResolve) {
+					this.pendingResolve(false);
+					this.pendingResolve = null;
+				}
+			}, timeoutMs);
 		});
 	}
 
 	/**
-	 * Show inline diff preview in the editor (legacy method for stats only).
+	 * Show inline diff preview in the editor (without waiting for user decision).
 	 * @param editor The text editor
 	 * @param originalContent The original file content
 	 * @param fixedContent The fixed content from PHPCBF
@@ -309,44 +374,7 @@ export class InlineDiffPreview implements Disposable {
 		fixedContent: string
 	): { additions: number; deletions: number } {
 		this.activeEditor = editor;
-		this.deletedLinesContent.clear();
-
-		const changes = computeLineDiff(originalContent, fixedContent);
-
-		const additionDecorations: DecorationOptions[] = [];
-
-		let additions = 0;
-		let deletions = 0;
-
-		// We need to show the preview on the FIXED content
-		// So we'll track which lines in the fixed content are new
-		const fixedLines = fixedContent.split('\n');
-
-		for (const change of changes) {
-			if (change.type === 'add') {
-				additions++;
-				const line = change.lineNumber;
-				if (line < fixedLines.length) {
-					additionDecorations.push({
-						range: new Range(
-							new Position(line, 0),
-							new Position(line, fixedLines[line].length)
-						),
-						hoverMessage: '**Added line**'
-					});
-				}
-			} else if (change.type === 'delete') {
-				deletions++;
-				// For deletions, we'll show them at the corresponding position
-				// Since the line won't exist in the preview, we show at nearest line
-				this.deletedLinesContent.set(change.lineNumber, change.oldText || '');
-			}
-		}
-
-		// Apply decorations for additions (deletions are trickier since the lines don't exist in preview)
-		editor.setDecorations(this.additionDecorationType, additionDecorations);
-
-		return { additions, deletions };
+		return this.computeAndApplyDecorations(editor, originalContent, fixedContent);
 	}
 
 	/**
@@ -362,19 +390,7 @@ export class InlineDiffPreview implements Disposable {
 		this.deletedLinesContent.clear();
 
 		// Cleanup CodeLens
-		this.codeLensProvider.clearActiveDocument();
-		if (this.codeLensRegistration) {
-			this.codeLensRegistration.dispose();
-			this.codeLensRegistration = null;
-		}
-		if (this.applyCommandRegistration) {
-			this.applyCommandRegistration.dispose();
-			this.applyCommandRegistration = null;
-		}
-		if (this.cancelCommandRegistration) {
-			this.cancelCommandRegistration.dispose();
-			this.cancelCommandRegistration = null;
-		}
+		this.cleanupCodeLens();
 
 		// Resolve any pending promise as cancelled
 		if (this.pendingResolve) {

--- a/phpcs/src/inline-diff.ts
+++ b/phpcs/src/inline-diff.ts
@@ -342,10 +342,22 @@ export class InlineDiffPreview implements Disposable {
 					this.trackedHunks.forEach((t, i) => t.index = i);
 
 					if (this.trackedHunks.length === 0) {
-						// No more hunks to review
+						// No more hunks to review - clean up all visual artifacts
 						if (this.pendingResolve) {
-							this.pendingResolve([]);
+							const resolve = this.pendingResolve;
+
+							// Clear all state immediately to prevent stale data issues
+							this.clearDecorations();
 							this.pendingResolve = null;
+							this.activeEditor = null;
+
+							// Dispose CodeLens registration to prevent refresh issues
+							if (this.codeLensRegistration) {
+								this.codeLensRegistration.dispose();
+								this.codeLensRegistration = null;
+							}
+
+							resolve([]);
 						}
 					} else if (this.activeEditor) {
 						// Update display only if editor is still active

--- a/phpcs/src/inline-diff.ts
+++ b/phpcs/src/inline-diff.ts
@@ -144,6 +144,7 @@ export class InlineDiffPreview implements Disposable {
 	private codeLensProvider: HunkActionCodeLensProvider;
 	private codeLensRegistration: Disposable | null = null;
 	private commandRegistrations: Disposable[] = [];
+	private legacyCommandRegistrations: Disposable[] = [];
 	private pendingResolve: ((acceptedHunks: PreviewDiffHunk[]) => void) | null = null;
 
 	constructor() {
@@ -187,6 +188,10 @@ export class InlineDiffPreview implements Disposable {
 		});
 
 		this.codeLensProvider = new HunkActionCodeLensProvider();
+
+		// Register hunk action commands once at construction time
+		// Commands check instance state to determine behavior
+		this.registerHunkCommands();
 	}
 
 	/**
@@ -299,8 +304,9 @@ export class InlineDiffPreview implements Disposable {
 
 	/**
 	 * Register commands for hunk actions.
+	 * Called once at construction time. Commands check instance state to determine behavior.
 	 */
-	private registerCommands(): void {
+	private registerHunkCommands(): void {
 		// Accept single hunk - immediately apply just this one
 		this.commandRegistrations.push(
 			commands.registerCommand('phpcs.hunkAccept', (index: number) => {
@@ -366,16 +372,6 @@ export class InlineDiffPreview implements Disposable {
 	}
 
 	/**
-	 * Cleanup command registrations.
-	 */
-	private cleanupCommands(): void {
-		for (const reg of this.commandRegistrations) {
-			reg.dispose();
-		}
-		this.commandRegistrations = [];
-	}
-
-	/**
 	 * Show inline diff preview with per-hunk actions.
 	 * @param editor The text editor
 	 * @param originalContent The original file content
@@ -397,9 +393,6 @@ export class InlineDiffPreview implements Disposable {
 			hunk,
 			index
 		}));
-
-		// Register commands
-		this.registerCommands();
 
 		// Register CodeLens provider
 		this.codeLensProvider.setHunks(editor.document.uri.toString(), this.trackedHunks);
@@ -430,10 +423,10 @@ export class InlineDiffPreview implements Disposable {
 		this.activeEditor = editor;
 
 		return new Promise<boolean>((resolve) => {
-			this.commandRegistrations.push(
+			this.legacyCommandRegistrations.push(
 				commands.registerCommand('phpcs.inlineDiffApply', () => resolve(true))
 			);
-			this.commandRegistrations.push(
+			this.legacyCommandRegistrations.push(
 				commands.registerCommand('phpcs.inlineDiffCancel', () => resolve(false))
 			);
 
@@ -493,7 +486,11 @@ export class InlineDiffPreview implements Disposable {
 			this.codeLensRegistration = null;
 		}
 
-		this.cleanupCommands();
+		// Clean up legacy commands (registered per-preview)
+		for (const reg of this.legacyCommandRegistrations) {
+			reg.dispose();
+		}
+		this.legacyCommandRegistrations = [];
 
 		if (this.pendingResolve) {
 			this.pendingResolve([]);
@@ -507,6 +504,11 @@ export class InlineDiffPreview implements Disposable {
 		this.additionDecorationType.dispose();
 		this.insertionDecorationType.dispose();
 		this.codeLensProvider.dispose();
+		// Dispose hunk command registrations (registered once at construction)
+		for (const reg of this.commandRegistrations) {
+			reg.dispose();
+		}
+		this.commandRegistrations = [];
 	}
 }
 

--- a/phpcs/src/inline-diff.ts
+++ b/phpcs/src/inline-diff.ts
@@ -273,6 +273,8 @@ export class InlineDiffPreview implements Disposable {
 			commands.registerCommand('phpcs.hunkAccept', (index: number) => {
 				if (this.pendingResolve && index >= 0 && index < this.trackedHunks.length) {
 					const hunk = this.trackedHunks[index].hunk;
+					// Clear decorations immediately before resolving
+					this.clearDecorations();
 					this.pendingResolve([hunk]);
 					this.pendingResolve = null;
 				}
@@ -311,6 +313,8 @@ export class InlineDiffPreview implements Disposable {
 			commands.registerCommand('phpcs.hunkAcceptAll', () => {
 				if (this.pendingResolve) {
 					const allHunks = this.trackedHunks.map(t => t.hunk);
+					// Clear decorations immediately before resolving
+					this.clearDecorations();
 					this.pendingResolve(allHunks);
 					this.pendingResolve = null;
 				}
@@ -421,19 +425,36 @@ export class InlineDiffPreview implements Disposable {
 	}
 
 	/**
-	 * Clear all decorations and cleanup.
+	 * Clear decorations and CodeLens without full cleanup.
+	 * Used when accepting hunks to remove visual indicators before applying changes.
 	 */
-	public clearPreview(): void {
-		if (this.activeEditor) {
+	private clearDecorations(): void {
+		// Use window.activeTextEditor to ensure we get the current editor
+		// This helps with VS Code's rendering refresh
+		const editor = window.activeTextEditor || this.activeEditor;
+		if (editor) {
+			editor.setDecorations(this.deletionDecorationType, []);
+			editor.setDecorations(this.additionDecorationType, []);
+			editor.setDecorations(this.insertionDecorationType, []);
+		}
+		// Also clear on cached editor if different
+		if (this.activeEditor && this.activeEditor !== editor) {
 			this.activeEditor.setDecorations(this.deletionDecorationType, []);
 			this.activeEditor.setDecorations(this.additionDecorationType, []);
 			this.activeEditor.setDecorations(this.insertionDecorationType, []);
 		}
+		this.codeLensProvider.clear();
+	}
+
+	/**
+	 * Clear all decorations and cleanup.
+	 */
+	public clearPreview(): void {
+		this.clearDecorations();
 
 		this.activeEditor = null;
 		this.trackedHunks = [];
 
-		this.codeLensProvider.clear();
 		if (this.codeLensRegistration) {
 			this.codeLensRegistration.dispose();
 			this.codeLensRegistration = null;

--- a/phpcs/src/inline-diff.ts
+++ b/phpcs/src/inline-diff.ts
@@ -71,7 +71,7 @@ class HunkActionCodeLensProvider implements CodeLensProvider {
 		const statusText = `PHPCBF Preview: ${totalCount} change(s) to review`;
 		lenses.push(new CodeLens(topRange, {
 			title: statusText,
-			command: '',
+			command: 'phpcs.noop',
 			tooltip: 'Review each change and click Accept or Reject'
 		}));
 
@@ -307,6 +307,13 @@ export class InlineDiffPreview implements Disposable {
 	 * Called once at construction time. Commands check instance state to determine behavior.
 	 */
 	private registerHunkCommands(): void {
+		// No-op command for informational CodeLens (e.g., status indicator)
+		this.commandRegistrations.push(
+			commands.registerCommand('phpcs.noop', () => {
+				// Intentionally empty - used for informational CodeLens
+			})
+		);
+
 		// Accept single hunk - immediately apply just this one
 		this.commandRegistrations.push(
 			commands.registerCommand('phpcs.hunkAccept', (index: number) => {

--- a/phpcs/src/inline-diff.ts
+++ b/phpcs/src/inline-diff.ts
@@ -17,129 +17,45 @@ import {
 	CodeLens,
 	TextDocument,
 	CancellationToken,
-	Command,
 	languages,
-	commands
+	commands,
+	EventEmitter,
+	Event
 } from "vscode";
 
+import { PreviewDiffHunk } from "./protocol";
+
 /**
- * Represents a line change in a diff.
+ * Tracked hunk for preview.
  */
-interface LineChange {
-	type: 'add' | 'delete' | 'modify';
-	lineNumber: number;
-	oldText?: string;
-	newText?: string;
+interface TrackedHunk {
+	hunk: PreviewDiffHunk;
+	index: number;
 }
 
 /**
- * Computes line-by-line diff between two texts.
- * Returns changes needed to transform original into fixed.
+ * CodeLens provider for per-hunk accept/reject actions.
  */
-function computeLineDiff(original: string, fixed: string): LineChange[] {
-	const originalLines = original.split('\n');
-	const fixedLines = fixed.split('\n');
-	const changes: LineChange[] = [];
-
-	// Simple LCS-based diff algorithm
-	const lcs = computeLCS(originalLines, fixedLines);
-
-	let origIdx = 0;
-	let fixedIdx = 0;
-	let lcsIdx = 0;
-
-	while (origIdx < originalLines.length || fixedIdx < fixedLines.length) {
-		if (lcsIdx < lcs.length &&
-			origIdx < originalLines.length &&
-			fixedIdx < fixedLines.length &&
-			originalLines[origIdx] === lcs[lcsIdx] &&
-			fixedLines[fixedIdx] === lcs[lcsIdx]) {
-			// Lines match - no change
-			origIdx++;
-			fixedIdx++;
-			lcsIdx++;
-		} else if (fixedIdx < fixedLines.length &&
-				   (lcsIdx >= lcs.length || fixedLines[fixedIdx] !== lcs[lcsIdx])) {
-			// Line added in fixed
-			changes.push({
-				type: 'add',
-				lineNumber: fixedIdx,
-				newText: fixedLines[fixedIdx]
-			});
-			fixedIdx++;
-		} else if (origIdx < originalLines.length &&
-				   (lcsIdx >= lcs.length || originalLines[origIdx] !== lcs[lcsIdx])) {
-			// Line deleted from original
-			changes.push({
-				type: 'delete',
-				lineNumber: origIdx,
-				oldText: originalLines[origIdx]
-			});
-			origIdx++;
-		}
-	}
-
-	return changes;
-}
-
-/**
- * Compute Longest Common Subsequence of two line arrays.
- */
-function computeLCS(a: string[], b: string[]): string[] {
-	const m = a.length;
-	const n = b.length;
-
-	// Build LCS length table
-	const dp: number[][] = Array(m + 1).fill(null).map(() => Array(n + 1).fill(0));
-
-	for (let i = 1; i <= m; i++) {
-		for (let j = 1; j <= n; j++) {
-			if (a[i - 1] === b[j - 1]) {
-				dp[i][j] = dp[i - 1][j - 1] + 1;
-			} else {
-				dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
-			}
-		}
-	}
-
-	// Backtrack to find LCS
-	const lcs: string[] = [];
-	let i = m, j = n;
-	while (i > 0 && j > 0) {
-		if (a[i - 1] === b[j - 1]) {
-			lcs.unshift(a[i - 1]);
-			i--;
-			j--;
-		} else if (dp[i - 1][j] > dp[i][j - 1]) {
-			i--;
-		} else {
-			j--;
-		}
-	}
-
-	return lcs;
-}
-
-/**
- * CodeLens provider for inline diff accept/reject actions.
- */
-class DiffActionCodeLensProvider implements CodeLensProvider {
+class HunkActionCodeLensProvider implements CodeLensProvider {
 	private documentUri: string | null = null;
-	private stats: { additions: number; deletions: number } = { additions: 0, deletions: 0 };
-	private targetLine: number = 0;
+	private trackedHunks: TrackedHunk[] = [];
+	private _onDidChangeCodeLenses = new EventEmitter<void>();
+	public readonly onDidChangeCodeLenses: Event<void> = this._onDidChangeCodeLenses.event;
 
-	public setActiveDocument(
-		uri: string,
-		stats: { additions: number; deletions: number },
-		targetLine?: number
-	): void {
+	public setHunks(uri: string, hunks: TrackedHunk[]): void {
 		this.documentUri = uri;
-		this.stats = stats;
-		this.targetLine = targetLine ?? 0;
+		this.trackedHunks = hunks;
+		this._onDidChangeCodeLenses.fire();
 	}
 
-	public clearActiveDocument(): void {
+	public clear(): void {
 		this.documentUri = null;
+		this.trackedHunks = [];
+		this._onDidChangeCodeLenses.fire();
+	}
+
+	public refresh(): void {
+		this._onDidChangeCodeLenses.fire();
 	}
 
 	public provideCodeLenses(document: TextDocument, _token: CancellationToken): CodeLens[] {
@@ -147,244 +63,361 @@ class DiffActionCodeLensProvider implements CodeLensProvider {
 			return [];
 		}
 
-		// Position CodeLens at the target line (or line before it for visibility)
-		const line = Math.max(0, this.targetLine);
-		const range = new Range(line, 0, line, 0);
+		const lenses: CodeLens[] = [];
+		const topRange = new Range(0, 0, 0, 0);
+		const totalCount = this.trackedHunks.length;
 
-		const applyCommand: Command = {
-			title: '✓ Apply Changes',
-			command: 'phpcs.inlineDiffApply',
-			tooltip: 'Apply PHPCBF fixes to this file'
-		};
-
-		const cancelCommand: Command = {
-			title: '✗ Cancel',
-			command: 'phpcs.inlineDiffCancel',
-			tooltip: 'Cancel and restore original content'
-		};
-
-		const statsText = `PHPCBF Preview: ${this.stats.additions} addition(s), ${this.stats.deletions} deletion(s)`;
-		const statsCommand: Command = {
-			title: statsText,
+		// Status indicator at the top
+		const statusText = `PHPCBF Preview: ${totalCount} change(s) to review`;
+		lenses.push(new CodeLens(topRange, {
+			title: statusText,
 			command: '',
-			tooltip: 'Changes that will be applied'
-		};
+			tooltip: 'Review each change and click Accept or Reject'
+		}));
 
-		return [
-			new CodeLens(range, statsCommand),
-			new CodeLens(range, applyCommand),
-			new CodeLens(range, cancelCommand)
-		];
+		// Accept All button
+		if (totalCount > 0) {
+			lenses.push(new CodeLens(topRange, {
+				title: '$(check-all) Accept All',
+				command: 'phpcs.hunkAcceptAll',
+				tooltip: 'Apply all changes'
+			}));
+		}
+
+		// Cancel button
+		lenses.push(new CodeLens(topRange, {
+			title: '$(x) Cancel',
+			command: 'phpcs.hunkCancel',
+			tooltip: 'Cancel without applying any changes'
+		}));
+
+		// Per-hunk actions
+		for (const tracked of this.trackedHunks) {
+			const hunk = tracked.hunk;
+			const line = hunk.originalStart;
+			const range = new Range(line, 0, line, 0);
+
+			// Accept button - applies this change immediately
+			lenses.push(new CodeLens(range, {
+				title: '$(check) Accept',
+				command: 'phpcs.hunkAccept',
+				arguments: [tracked.index],
+				tooltip: 'Apply this change'
+			}));
+
+			// Accept all button - applies all changes
+			lenses.push(new CodeLens(range, {
+				title: '$(check-all) Accept all',
+				command: 'phpcs.hunkAcceptAll',
+				tooltip: 'Apply all changes'
+			}));
+
+			// Reject button - removes this change from preview
+			lenses.push(new CodeLens(range, {
+				title: '$(x) Reject',
+				command: 'phpcs.hunkReject',
+				arguments: [tracked.index],
+				tooltip: 'Skip this change'
+			}));
+		}
+
+		return lenses;
+	}
+
+	public dispose(): void {
+		this._onDidChangeCodeLenses.dispose();
 	}
 }
 
 /**
- * Manages inline diff preview decorations in the editor.
+ * Manages inline diff preview decorations with per-hunk accept/reject actions.
  */
 export class InlineDiffPreview implements Disposable {
-	private additionDecorationType: TextEditorDecorationType;
 	private deletionDecorationType: TextEditorDecorationType;
-	private deletionLineDecorationType: TextEditorDecorationType;
+	private additionDecorationType: TextEditorDecorationType;
+	private insertionDecorationType: TextEditorDecorationType;
+
 	private activeEditor: TextEditor | null = null;
-	private deletedLinesContent: Map<number, string> = new Map();
+	private trackedHunks: TrackedHunk[] = [];
 
 	// CodeLens support
-	private codeLensProvider: DiffActionCodeLensProvider;
+	private codeLensProvider: HunkActionCodeLensProvider;
 	private codeLensRegistration: Disposable | null = null;
-	private applyCommandRegistration: Disposable | null = null;
-	private cancelCommandRegistration: Disposable | null = null;
-	private pendingResolve: ((value: boolean) => void) | null = null;
-	private timeoutId: ReturnType<typeof setTimeout> | null = null;
+	private commandRegistrations: Disposable[] = [];
+	private pendingResolve: ((acceptedHunks: PreviewDiffHunk[]) => void) | null = null;
 
 	constructor() {
-		// Green background for additions
-		this.additionDecorationType = window.createTextEditorDecorationType({
-			backgroundColor: new ThemeColor('diffEditor.insertedTextBackground'),
-			isWholeLine: true,
-			overviewRulerColor: new ThemeColor('editorOverviewRuler.addedForeground'),
-			overviewRulerLane: 1
-		});
-
-		// Red background for deletions (shown as gutter indicator since line won't exist)
+		// Red background for deletions (lines being removed)
 		this.deletionDecorationType = window.createTextEditorDecorationType({
-			backgroundColor: new ThemeColor('diffEditor.removedTextBackground'),
+			backgroundColor: 'rgba(255, 0, 0, 0.2)',
 			isWholeLine: true,
 			overviewRulerColor: new ThemeColor('editorOverviewRuler.deletedForeground'),
-			overviewRulerLane: 1
+			overviewRulerLane: 1,
+			before: {
+				contentText: '−',
+				color: 'rgba(255, 100, 100, 0.8)',
+				margin: '0 8px 0 0'
+			}
 		});
 
-		// For showing deleted content in gutter/after
-		this.deletionLineDecorationType = window.createTextEditorDecorationType({
-			after: {
-				color: new ThemeColor('editorGutter.deletedBackground'),
-				fontStyle: 'italic'
-			},
-			isWholeLine: true
+		// Green background for showing replacement content inline
+		this.additionDecorationType = window.createTextEditorDecorationType({
+			isWholeLine: true,
 		});
 
-		this.codeLensProvider = new DiffActionCodeLensProvider();
+		// Green background for pure insertions (shown as a decoration on adjacent line)
+		this.insertionDecorationType = window.createTextEditorDecorationType({
+			backgroundColor: 'rgba(0, 200, 0, 0.2)',
+			isWholeLine: true,
+			overviewRulerColor: new ThemeColor('editorOverviewRuler.addedForeground'),
+			overviewRulerLane: 1,
+			before: {
+				contentText: '+',
+				color: 'rgba(0, 200, 0, 0.8)',
+				margin: '0 8px 0 0'
+			}
+		});
+
+		this.codeLensProvider = new HunkActionCodeLensProvider();
 	}
 
 	/**
-	 * Compute diff and apply decorations to the editor.
-	 * @param editor The text editor
-	 * @param originalContent The original file content
-	 * @param fixedContent The fixed content from PHPCBF
-	 * @returns Object with line counts and decorations applied
+	 * Update decorations based on current hunks.
 	 */
-	private computeAndApplyDecorations(
-		editor: TextEditor,
-		originalContent: string,
-		fixedContent: string
-	): { additions: number; deletions: number } {
-		this.deletedLinesContent.clear();
-		const changes = computeLineDiff(originalContent, fixedContent);
+	private updateDecorations(): void {
+		if (!this.activeEditor) {
+			return;
+		}
+
+		const deletionDecorations: DecorationOptions[] = [];
 		const additionDecorations: DecorationOptions[] = [];
+		const insertionDecorations: DecorationOptions[] = [];
 
-		let additions = 0;
-		let deletions = 0;
+		for (const tracked of this.trackedHunks) {
+			const hunk = tracked.hunk;
+			const startLine = hunk.originalStart;
+			const endLine = hunk.originalStart + Math.max(hunk.originalLength, 1) - 1;
+			const safeEndLine = Math.min(endLine, this.activeEditor.document.lineCount - 1);
 
-		const fixedLines = fixedContent.split('\n');
+			if (hunk.originalLength > 0 && hunk.modifiedLength > 0) {
+				// Replacement: show deletion with inline preview of replacement
+				const range = new Range(
+					new Position(startLine, 0),
+					new Position(safeEndLine, this.activeEditor.document.lineAt(safeEndLine).text.length)
+				);
+				const replacementPreview = hunk.modifiedLines[0]?.substring(0, 80) || '';
+				const moreLines = hunk.modifiedLength > 1 ? ` (+${hunk.modifiedLength - 1} more)` : '';
 
-		for (const change of changes) {
-			if (change.type === 'add') {
-				additions++;
-				const line = change.lineNumber;
-				if (line < fixedLines.length) {
-					additionDecorations.push({
-						range: new Range(
-							new Position(line, 0),
-							new Position(line, fixedLines[line].length)
-						),
-						hoverMessage: '**Added line**'
-					});
-				}
-			} else if (change.type === 'delete') {
-				deletions++;
-				this.deletedLinesContent.set(change.lineNumber, change.oldText || '');
+				deletionDecorations.push({
+					range,
+					hoverMessage: `**Replace with:**\n\`\`\`\n${hunk.modifiedLines.join('\n')}\n\`\`\``,
+					renderOptions: {
+						after: {
+							contentText: ` → ${replacementPreview}${moreLines}`,
+							color: 'rgba(0, 180, 0, 0.9)',
+							fontStyle: 'italic',
+							backgroundColor: 'rgba(0, 180, 0, 0.15)',
+							margin: '0 0 0 1em'
+						}
+					}
+				});
+			} else if (hunk.originalLength > 0) {
+				// Pure deletion
+				const range = new Range(
+					new Position(startLine, 0),
+					new Position(safeEndLine, this.activeEditor.document.lineAt(safeEndLine).text.length)
+				);
+				deletionDecorations.push({
+					range,
+					hoverMessage: `**Delete ${hunk.originalLength} line(s)**`
+				});
+			} else if (hunk.modifiedLength > 0) {
+				// Pure insertion - show on the line before insertion point
+				const insertLine = Math.max(0, startLine - 1);
+				const lineText = this.activeEditor.document.lineAt(insertLine).text;
+				const range = new Range(
+					new Position(insertLine, 0),
+					new Position(insertLine, lineText.length)
+				);
+
+				const insertPreview = hunk.modifiedLines.map(l => l.trim()).join(' ').substring(0, 60);
+				const moreInfo = hunk.modifiedLength > 1 ? ` (${hunk.modifiedLength} lines)` : '';
+
+				insertionDecorations.push({
+					range,
+					hoverMessage: `**Insert after this line:**\n\`\`\`\n${hunk.modifiedLines.join('\n')}\n\`\`\``,
+					renderOptions: {
+						after: {
+							contentText: ` ↓ Insert: ${insertPreview}${moreInfo}`,
+							color: 'rgba(0, 180, 0, 0.9)',
+							fontStyle: 'italic',
+							backgroundColor: 'rgba(0, 180, 0, 0.15)',
+							margin: '0 0 0 1em'
+						}
+					}
+				});
 			}
 		}
 
-		editor.setDecorations(this.additionDecorationType, additionDecorations);
-
-		return { additions, deletions };
+		this.activeEditor.setDecorations(this.deletionDecorationType, deletionDecorations);
+		this.activeEditor.setDecorations(this.additionDecorationType, additionDecorations);
+		this.activeEditor.setDecorations(this.insertionDecorationType, insertionDecorations);
 	}
 
 	/**
-	 * Clean up CodeLens registrations and pending state.
+	 * Register commands for hunk actions.
 	 */
-	private cleanupCodeLens(): void {
-		// Clear timeout if active
-		if (this.timeoutId) {
-			clearTimeout(this.timeoutId);
-			this.timeoutId = null;
-		}
+	private registerCommands(): void {
+		// Accept single hunk - immediately apply just this one
+		this.commandRegistrations.push(
+			commands.registerCommand('phpcs.hunkAccept', (index: number) => {
+				if (this.pendingResolve && index >= 0 && index < this.trackedHunks.length) {
+					const hunk = this.trackedHunks[index].hunk;
+					this.pendingResolve([hunk]);
+					this.pendingResolve = null;
+				}
+			})
+		);
 
-		// Cleanup CodeLens provider
-		this.codeLensProvider.clearActiveDocument();
-		if (this.codeLensRegistration) {
-			this.codeLensRegistration.dispose();
-			this.codeLensRegistration = null;
-		}
-		if (this.applyCommandRegistration) {
-			this.applyCommandRegistration.dispose();
-			this.applyCommandRegistration = null;
-		}
-		if (this.cancelCommandRegistration) {
-			this.cancelCommandRegistration.dispose();
-			this.cancelCommandRegistration = null;
-		}
+		// Reject single hunk - remove from preview and continue
+		this.commandRegistrations.push(
+			commands.registerCommand('phpcs.hunkReject', (index: number) => {
+				if (index >= 0 && index < this.trackedHunks.length) {
+					// Remove this hunk from tracking
+					this.trackedHunks.splice(index, 1);
+					// Re-index remaining hunks
+					this.trackedHunks.forEach((t, i) => t.index = i);
+
+					if (this.trackedHunks.length === 0) {
+						// No more hunks to review
+						if (this.pendingResolve) {
+							this.pendingResolve([]);
+							this.pendingResolve = null;
+						}
+					} else {
+						// Update display
+						this.codeLensProvider.setHunks(
+							this.activeEditor!.document.uri.toString(),
+							this.trackedHunks
+						);
+						this.updateDecorations();
+					}
+				}
+			})
+		);
+
+		// Accept all hunks - apply all remaining
+		this.commandRegistrations.push(
+			commands.registerCommand('phpcs.hunkAcceptAll', () => {
+				if (this.pendingResolve) {
+					const allHunks = this.trackedHunks.map(t => t.hunk);
+					this.pendingResolve(allHunks);
+					this.pendingResolve = null;
+				}
+			})
+		);
+
+		// Cancel - close without applying
+		this.commandRegistrations.push(
+			commands.registerCommand('phpcs.hunkCancel', () => {
+				if (this.pendingResolve) {
+					this.pendingResolve([]);
+					this.pendingResolve = null;
+				}
+			})
+		);
 	}
 
 	/**
-	 * Show inline diff preview in the editor and wait for user decision.
+	 * Cleanup command registrations.
+	 */
+	private cleanupCommands(): void {
+		for (const reg of this.commandRegistrations) {
+			reg.dispose();
+		}
+		this.commandRegistrations = [];
+	}
+
+	/**
+	 * Show inline diff preview with per-hunk actions.
 	 * @param editor The text editor
 	 * @param originalContent The original file content
-	 * @param fixedContent The fixed content from PHPCBF
-	 * @param targetLine Optional line number for positioning the CodeLens (0-indexed)
-	 * @returns Promise that resolves to true if user accepts, false if cancels
+	 * @param hunks The diff hunks to preview
+	 * @returns Promise that resolves to the list of accepted hunks
 	 */
-	public async showPreviewAndWait(
+	public async showHunkPreview(
 		editor: TextEditor,
-		originalContent: string,
-		fixedContent: string,
-		targetLine?: number
-	): Promise<boolean> {
-		// Clear any existing preview state to prevent race conditions
-		if (this.pendingResolve) {
-			this.pendingResolve(false);
-			this.pendingResolve = null;
-		}
-		this.cleanupCodeLens();
+		_originalContent: string,
+		hunks: PreviewDiffHunk[]
+	): Promise<PreviewDiffHunk[]> {
+		// Clear any existing preview
+		this.clearPreview();
 
 		this.activeEditor = editor;
 
-		// Compute and apply decorations
-		const { additions, deletions } = this.computeAndApplyDecorations(
-			editor,
-			originalContent,
-			fixedContent
-		);
+		// Initialize tracked hunks
+		this.trackedHunks = hunks.map((hunk, index) => ({
+			hunk,
+			index
+		}));
 
-		// Register CodeLens provider and commands
-		this.codeLensProvider.setActiveDocument(editor.document.uri.toString(), { additions, deletions }, targetLine);
+		// Register commands
+		this.registerCommands();
 
-		// Register commands for accept/cancel
-		this.applyCommandRegistration = commands.registerCommand('phpcs.inlineDiffApply', () => {
-			if (this.pendingResolve) {
-				this.pendingResolve(true);
-				this.pendingResolve = null;
-			}
-		});
-
-		this.cancelCommandRegistration = commands.registerCommand('phpcs.inlineDiffCancel', () => {
-			if (this.pendingResolve) {
-				this.pendingResolve(false);
-				this.pendingResolve = null;
-			}
-		});
-
-		// Register CodeLens provider for PHP files
+		// Register CodeLens provider
+		this.codeLensProvider.setHunks(editor.document.uri.toString(), this.trackedHunks);
 		this.codeLensRegistration = languages.registerCodeLensProvider(
 			{ scheme: 'file', language: 'php' },
 			this.codeLensProvider
 		);
 
-		// Wait for user decision with timeout (5 minutes)
-		const timeoutMs = 300000;
+		// Apply initial decorations
+		this.updateDecorations();
 
-		return new Promise<boolean>((resolve) => {
-			this.pendingResolve = (value: boolean) => {
-				if (this.timeoutId) {
-					clearTimeout(this.timeoutId);
-					this.timeoutId = null;
-				}
-				resolve(value);
-			};
-
-			this.timeoutId = setTimeout(() => {
-				if (this.pendingResolve) {
-					this.pendingResolve(false);
-					this.pendingResolve = null;
-				}
-			}, timeoutMs);
+		// Wait for user action
+		return new Promise<PreviewDiffHunk[]>((resolve) => {
+			this.pendingResolve = resolve;
 		});
 	}
 
 	/**
-	 * Show inline diff preview in the editor (without waiting for user decision).
-	 * @param editor The text editor
-	 * @param originalContent The original file content
-	 * @param fixedContent The fixed content from PHPCBF
-	 * @returns Object with line counts for display
+	 * Legacy method for backward compatibility.
+	 */
+	public async showPreviewAndWait(
+		editor: TextEditor,
+		_originalContent: string,
+		_fixedContent: string,
+		_targetLine?: number
+	): Promise<boolean> {
+		this.clearPreview();
+		this.activeEditor = editor;
+
+		return new Promise<boolean>((resolve) => {
+			this.commandRegistrations.push(
+				commands.registerCommand('phpcs.inlineDiffApply', () => resolve(true))
+			);
+			this.commandRegistrations.push(
+				commands.registerCommand('phpcs.inlineDiffCancel', () => resolve(false))
+			);
+
+			window.showInformationMessage(
+				'PHPCBF Preview: Apply changes?',
+				'Apply',
+				'Cancel'
+			).then(choice => resolve(choice === 'Apply'));
+		});
+	}
+
+	/**
+	 * Legacy method for backward compatibility.
 	 */
 	public showPreview(
 		editor: TextEditor,
-		originalContent: string,
-		fixedContent: string
+		_originalContent: string,
+		_fixedContent: string
 	): { additions: number; deletions: number } {
 		this.activeEditor = editor;
-		return this.computeAndApplyDecorations(editor, originalContent, fixedContent);
+		return { additions: 0, deletions: 0 };
 	}
 
 	/**
@@ -392,27 +425,50 @@ export class InlineDiffPreview implements Disposable {
 	 */
 	public clearPreview(): void {
 		if (this.activeEditor) {
-			this.activeEditor.setDecorations(this.additionDecorationType, []);
 			this.activeEditor.setDecorations(this.deletionDecorationType, []);
-			this.activeEditor.setDecorations(this.deletionLineDecorationType, []);
+			this.activeEditor.setDecorations(this.additionDecorationType, []);
+			this.activeEditor.setDecorations(this.insertionDecorationType, []);
 		}
+
 		this.activeEditor = null;
-		this.deletedLinesContent.clear();
+		this.trackedHunks = [];
 
-		// Cleanup CodeLens
-		this.cleanupCodeLens();
+		this.codeLensProvider.clear();
+		if (this.codeLensRegistration) {
+			this.codeLensRegistration.dispose();
+			this.codeLensRegistration = null;
+		}
 
-		// Resolve any pending promise as cancelled
+		this.cleanupCommands();
+
 		if (this.pendingResolve) {
-			this.pendingResolve(false);
+			this.pendingResolve([]);
 			this.pendingResolve = null;
 		}
 	}
 
 	public dispose(): void {
 		this.clearPreview();
-		this.additionDecorationType.dispose();
 		this.deletionDecorationType.dispose();
-		this.deletionLineDecorationType.dispose();
+		this.additionDecorationType.dispose();
+		this.insertionDecorationType.dispose();
+		this.codeLensProvider.dispose();
 	}
+}
+
+/**
+ * Apply selected hunks to the original content.
+ * Hunks are applied from bottom to top to preserve line numbers.
+ */
+export function applySelectedHunks(originalContent: string, hunks: PreviewDiffHunk[]): string {
+	const lines = originalContent.split('\n');
+
+	// Sort hunks by originalStart descending (apply from bottom to top)
+	const sortedHunks = [...hunks].sort((a, b) => b.originalStart - a.originalStart);
+
+	for (const hunk of sortedHunks) {
+		lines.splice(hunk.originalStart, hunk.originalLength, ...hunk.modifiedLines);
+	}
+
+	return lines.join('\n');
 }

--- a/phpcs/src/inline-diff.ts
+++ b/phpcs/src/inline-diff.ts
@@ -149,40 +149,43 @@ export class InlineDiffPreview implements Disposable {
 
 	constructor() {
 		// Red background for deletions (lines being removed)
+		// Uses theme-aware colors for better compatibility with all themes
 		this.deletionDecorationType = window.createTextEditorDecorationType({
-			backgroundColor: 'rgba(255, 0, 0, 0.2)',
+			backgroundColor: new ThemeColor('diffEditor.removedTextBackground'),
 			isWholeLine: true,
 			overviewRulerColor: new ThemeColor('editorOverviewRuler.deletedForeground'),
 			overviewRulerLane: 1,
 			before: {
 				contentText: '−',
-				color: 'rgba(255, 100, 100, 0.8)',
+				color: new ThemeColor('editorGutter.deletedBackground'),
 				margin: '0 8px 0 0'
 			}
 		});
 
 		// Green background for showing where additional lines will be added
+		// Uses theme-aware colors for better compatibility with all themes
 		this.additionDecorationType = window.createTextEditorDecorationType({
-			backgroundColor: 'rgba(0, 200, 0, 0.1)',
+			backgroundColor: new ThemeColor('diffEditor.insertedTextBackground'),
 			isWholeLine: true,
 			overviewRulerColor: new ThemeColor('editorOverviewRuler.addedForeground'),
 			overviewRulerLane: 1,
 			before: {
 				contentText: '+',
-				color: 'rgba(0, 200, 0, 0.6)',
+				color: new ThemeColor('editorGutter.addedBackground'),
 				margin: '0 8px 0 0'
 			}
 		});
 
 		// Green background for pure insertions (shown as a decoration on adjacent line)
+		// Uses theme-aware colors for better compatibility with all themes
 		this.insertionDecorationType = window.createTextEditorDecorationType({
-			backgroundColor: 'rgba(0, 200, 0, 0.2)',
+			backgroundColor: new ThemeColor('diffEditor.insertedTextBackground'),
 			isWholeLine: true,
 			overviewRulerColor: new ThemeColor('editorOverviewRuler.addedForeground'),
 			overviewRulerLane: 1,
 			before: {
 				contentText: '+',
-				color: 'rgba(0, 200, 0, 0.8)',
+				color: new ThemeColor('editorGutter.addedBackground'),
 				margin: '0 8px 0 0'
 			}
 		});
@@ -227,9 +230,9 @@ export class InlineDiffPreview implements Disposable {
 					renderOptions: {
 						after: {
 							contentText: ` → ${replacementPreview}${moreLines}`,
-							color: 'rgba(0, 180, 0, 0.9)',
+							color: new ThemeColor('editorGutter.addedBackground'),
 							fontStyle: 'italic',
-							backgroundColor: 'rgba(0, 180, 0, 0.15)',
+							backgroundColor: new ThemeColor('diffEditor.insertedTextBackground'),
 							margin: '0 0 0 1em'
 						}
 					}
@@ -251,7 +254,7 @@ export class InlineDiffPreview implements Disposable {
 							renderOptions: {
 								after: {
 									contentText: ` ↑ ${extraLines} line(s) added`,
-									color: 'rgba(0, 180, 0, 0.9)',
+									color: new ThemeColor('editorGutter.addedBackground'),
 									fontStyle: 'italic',
 									margin: '0 0 0 1em'
 								}
@@ -287,9 +290,9 @@ export class InlineDiffPreview implements Disposable {
 					renderOptions: {
 						after: {
 							contentText: ` ↓ Insert: ${insertPreview}${moreInfo}`,
-							color: 'rgba(0, 180, 0, 0.9)',
+							color: new ThemeColor('editorGutter.addedBackground'),
 							fontStyle: 'italic',
-							backgroundColor: 'rgba(0, 180, 0, 0.15)',
+							backgroundColor: new ThemeColor('diffEditor.insertedTextBackground'),
 							margin: '0 0 0 1em'
 						}
 					}

--- a/phpcs/src/inline-diff.ts
+++ b/phpcs/src/inline-diff.ts
@@ -1,0 +1,392 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) John R. D'Orazio. All rights reserved.
+ * Licensed under the MIT License. See License.md in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+"use strict";
+
+import {
+	window,
+	TextEditor,
+	TextEditorDecorationType,
+	Range,
+	Position,
+	DecorationOptions,
+	ThemeColor,
+	Disposable,
+	CodeLensProvider,
+	CodeLens,
+	TextDocument,
+	CancellationToken,
+	Command,
+	languages,
+	commands
+} from "vscode";
+
+/**
+ * Represents a line change in a diff.
+ */
+interface LineChange {
+	type: 'add' | 'delete' | 'modify';
+	lineNumber: number;
+	oldText?: string;
+	newText?: string;
+}
+
+/**
+ * Computes line-by-line diff between two texts.
+ * Returns changes needed to transform original into fixed.
+ */
+function computeLineDiff(original: string, fixed: string): LineChange[] {
+	const originalLines = original.split('\n');
+	const fixedLines = fixed.split('\n');
+	const changes: LineChange[] = [];
+
+	// Simple LCS-based diff algorithm
+	const lcs = computeLCS(originalLines, fixedLines);
+
+	let origIdx = 0;
+	let fixedIdx = 0;
+	let lcsIdx = 0;
+
+	while (origIdx < originalLines.length || fixedIdx < fixedLines.length) {
+		if (lcsIdx < lcs.length &&
+			origIdx < originalLines.length &&
+			fixedIdx < fixedLines.length &&
+			originalLines[origIdx] === lcs[lcsIdx] &&
+			fixedLines[fixedIdx] === lcs[lcsIdx]) {
+			// Lines match - no change
+			origIdx++;
+			fixedIdx++;
+			lcsIdx++;
+		} else if (fixedIdx < fixedLines.length &&
+				   (lcsIdx >= lcs.length || fixedLines[fixedIdx] !== lcs[lcsIdx])) {
+			// Line added in fixed
+			changes.push({
+				type: 'add',
+				lineNumber: fixedIdx,
+				newText: fixedLines[fixedIdx]
+			});
+			fixedIdx++;
+		} else if (origIdx < originalLines.length &&
+				   (lcsIdx >= lcs.length || originalLines[origIdx] !== lcs[lcsIdx])) {
+			// Line deleted from original
+			changes.push({
+				type: 'delete',
+				lineNumber: origIdx,
+				oldText: originalLines[origIdx]
+			});
+			origIdx++;
+		}
+	}
+
+	return changes;
+}
+
+/**
+ * Compute Longest Common Subsequence of two line arrays.
+ */
+function computeLCS(a: string[], b: string[]): string[] {
+	const m = a.length;
+	const n = b.length;
+
+	// Build LCS length table
+	const dp: number[][] = Array(m + 1).fill(null).map(() => Array(n + 1).fill(0));
+
+	for (let i = 1; i <= m; i++) {
+		for (let j = 1; j <= n; j++) {
+			if (a[i - 1] === b[j - 1]) {
+				dp[i][j] = dp[i - 1][j - 1] + 1;
+			} else {
+				dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+			}
+		}
+	}
+
+	// Backtrack to find LCS
+	const lcs: string[] = [];
+	let i = m, j = n;
+	while (i > 0 && j > 0) {
+		if (a[i - 1] === b[j - 1]) {
+			lcs.unshift(a[i - 1]);
+			i--;
+			j--;
+		} else if (dp[i - 1][j] > dp[i][j - 1]) {
+			i--;
+		} else {
+			j--;
+		}
+	}
+
+	return lcs;
+}
+
+/**
+ * CodeLens provider for inline diff accept/reject actions.
+ */
+class DiffActionCodeLensProvider implements CodeLensProvider {
+	private documentUri: string | null = null;
+	private stats: { additions: number; deletions: number } = { additions: 0, deletions: 0 };
+
+	public setActiveDocument(uri: string, stats: { additions: number; deletions: number }): void {
+		this.documentUri = uri;
+		this.stats = stats;
+	}
+
+	public clearActiveDocument(): void {
+		this.documentUri = null;
+	}
+
+	public provideCodeLenses(document: TextDocument, _token: CancellationToken): CodeLens[] {
+		if (this.documentUri !== document.uri.toString()) {
+			return [];
+		}
+
+		const range = new Range(0, 0, 0, 0);
+
+		const applyCommand: Command = {
+			title: '✓ Apply Changes',
+			command: 'phpcs.inlineDiffApply',
+			tooltip: 'Apply PHPCBF fixes to this file'
+		};
+
+		const cancelCommand: Command = {
+			title: '✗ Cancel',
+			command: 'phpcs.inlineDiffCancel',
+			tooltip: 'Cancel and restore original content'
+		};
+
+		const statsText = `PHPCBF Preview: ${this.stats.additions} addition(s), ${this.stats.deletions} deletion(s)`;
+		const statsCommand: Command = {
+			title: statsText,
+			command: '',
+			tooltip: 'Changes that will be applied'
+		};
+
+		return [
+			new CodeLens(range, statsCommand),
+			new CodeLens(range, applyCommand),
+			new CodeLens(range, cancelCommand)
+		];
+	}
+}
+
+/**
+ * Manages inline diff preview decorations in the editor.
+ */
+export class InlineDiffPreview implements Disposable {
+	private additionDecorationType: TextEditorDecorationType;
+	private deletionDecorationType: TextEditorDecorationType;
+	private deletionLineDecorationType: TextEditorDecorationType;
+	private activeEditor: TextEditor | null = null;
+	private deletedLinesContent: Map<number, string> = new Map();
+
+	// CodeLens support
+	private codeLensProvider: DiffActionCodeLensProvider;
+	private codeLensRegistration: Disposable | null = null;
+	private applyCommandRegistration: Disposable | null = null;
+	private cancelCommandRegistration: Disposable | null = null;
+	private pendingResolve: ((value: boolean) => void) | null = null;
+
+	constructor() {
+		// Green background for additions
+		this.additionDecorationType = window.createTextEditorDecorationType({
+			backgroundColor: new ThemeColor('diffEditor.insertedTextBackground'),
+			isWholeLine: true,
+			overviewRulerColor: new ThemeColor('editorOverviewRuler.addedForeground'),
+			overviewRulerLane: 1
+		});
+
+		// Red background for deletions (shown as gutter indicator since line won't exist)
+		this.deletionDecorationType = window.createTextEditorDecorationType({
+			backgroundColor: new ThemeColor('diffEditor.removedTextBackground'),
+			isWholeLine: true,
+			overviewRulerColor: new ThemeColor('editorOverviewRuler.deletedForeground'),
+			overviewRulerLane: 1
+		});
+
+		// For showing deleted content in gutter/after
+		this.deletionLineDecorationType = window.createTextEditorDecorationType({
+			after: {
+				color: new ThemeColor('editorGutter.deletedBackground'),
+				fontStyle: 'italic'
+			},
+			isWholeLine: true
+		});
+
+		this.codeLensProvider = new DiffActionCodeLensProvider();
+	}
+
+	/**
+	 * Show inline diff preview in the editor and wait for user decision.
+	 * @param editor The text editor
+	 * @param originalContent The original file content
+	 * @param fixedContent The fixed content from PHPCBF
+	 * @returns Promise that resolves to true if user accepts, false if cancels
+	 */
+	public async showPreviewAndWait(
+		editor: TextEditor,
+		originalContent: string,
+		fixedContent: string
+	): Promise<boolean> {
+		this.activeEditor = editor;
+		this.deletedLinesContent.clear();
+
+		const changes = computeLineDiff(originalContent, fixedContent);
+
+		const additionDecorations: DecorationOptions[] = [];
+
+		let additions = 0;
+		let deletions = 0;
+
+		// We need to show the preview on the FIXED content
+		// So we'll track which lines in the fixed content are new
+		const fixedLines = fixedContent.split('\n');
+
+		for (const change of changes) {
+			if (change.type === 'add') {
+				additions++;
+				const line = change.lineNumber;
+				if (line < fixedLines.length) {
+					additionDecorations.push({
+						range: new Range(
+							new Position(line, 0),
+							new Position(line, fixedLines[line].length)
+						),
+						hoverMessage: '**Added line**'
+					});
+				}
+			} else if (change.type === 'delete') {
+				deletions++;
+				// For deletions, we'll show them at the corresponding position
+				// Since the line won't exist in the preview, we show at nearest line
+				this.deletedLinesContent.set(change.lineNumber, change.oldText || '');
+			}
+		}
+
+		// Apply decorations for additions
+		editor.setDecorations(this.additionDecorationType, additionDecorations);
+
+		// Register CodeLens provider and commands
+		this.codeLensProvider.setActiveDocument(editor.document.uri.toString(), { additions, deletions });
+
+		// Register commands for accept/cancel
+		this.applyCommandRegistration = commands.registerCommand('phpcs.inlineDiffApply', () => {
+			if (this.pendingResolve) {
+				this.pendingResolve(true);
+				this.pendingResolve = null;
+			}
+		});
+
+		this.cancelCommandRegistration = commands.registerCommand('phpcs.inlineDiffCancel', () => {
+			if (this.pendingResolve) {
+				this.pendingResolve(false);
+				this.pendingResolve = null;
+			}
+		});
+
+		// Register CodeLens provider for PHP files
+		this.codeLensRegistration = languages.registerCodeLensProvider(
+			{ scheme: 'file', language: 'php' },
+			this.codeLensProvider
+		);
+
+		// Wait for user decision
+		return new Promise<boolean>((resolve) => {
+			this.pendingResolve = resolve;
+		});
+	}
+
+	/**
+	 * Show inline diff preview in the editor (legacy method for stats only).
+	 * @param editor The text editor
+	 * @param originalContent The original file content
+	 * @param fixedContent The fixed content from PHPCBF
+	 * @returns Object with line counts for display
+	 */
+	public showPreview(
+		editor: TextEditor,
+		originalContent: string,
+		fixedContent: string
+	): { additions: number; deletions: number } {
+		this.activeEditor = editor;
+		this.deletedLinesContent.clear();
+
+		const changes = computeLineDiff(originalContent, fixedContent);
+
+		const additionDecorations: DecorationOptions[] = [];
+
+		let additions = 0;
+		let deletions = 0;
+
+		// We need to show the preview on the FIXED content
+		// So we'll track which lines in the fixed content are new
+		const fixedLines = fixedContent.split('\n');
+
+		for (const change of changes) {
+			if (change.type === 'add') {
+				additions++;
+				const line = change.lineNumber;
+				if (line < fixedLines.length) {
+					additionDecorations.push({
+						range: new Range(
+							new Position(line, 0),
+							new Position(line, fixedLines[line].length)
+						),
+						hoverMessage: '**Added line**'
+					});
+				}
+			} else if (change.type === 'delete') {
+				deletions++;
+				// For deletions, we'll show them at the corresponding position
+				// Since the line won't exist in the preview, we show at nearest line
+				this.deletedLinesContent.set(change.lineNumber, change.oldText || '');
+			}
+		}
+
+		// Apply decorations for additions (deletions are trickier since the lines don't exist in preview)
+		editor.setDecorations(this.additionDecorationType, additionDecorations);
+
+		return { additions, deletions };
+	}
+
+	/**
+	 * Clear all decorations and cleanup.
+	 */
+	public clearPreview(): void {
+		if (this.activeEditor) {
+			this.activeEditor.setDecorations(this.additionDecorationType, []);
+			this.activeEditor.setDecorations(this.deletionDecorationType, []);
+			this.activeEditor.setDecorations(this.deletionLineDecorationType, []);
+		}
+		this.activeEditor = null;
+		this.deletedLinesContent.clear();
+
+		// Cleanup CodeLens
+		this.codeLensProvider.clearActiveDocument();
+		if (this.codeLensRegistration) {
+			this.codeLensRegistration.dispose();
+			this.codeLensRegistration = null;
+		}
+		if (this.applyCommandRegistration) {
+			this.applyCommandRegistration.dispose();
+			this.applyCommandRegistration = null;
+		}
+		if (this.cancelCommandRegistration) {
+			this.cancelCommandRegistration.dispose();
+			this.cancelCommandRegistration = null;
+		}
+
+		// Resolve any pending promise as cancelled
+		if (this.pendingResolve) {
+			this.pendingResolve(false);
+			this.pendingResolve = null;
+		}
+	}
+
+	public dispose(): void {
+		this.clearPreview();
+		this.additionDecorationType.dispose();
+		this.deletionDecorationType.dispose();
+		this.deletionLineDecorationType.dispose();
+	}
+}

--- a/phpcs/src/protocol.ts
+++ b/phpcs/src/protocol.ts
@@ -114,6 +114,12 @@ export interface ShowDiffPreviewParams {
 	 * The fixed content after PHPCBF.
 	 */
 	fixedContent: string;
+	/**
+	 * Optional target line for positioning the CodeLens (0-indexed).
+	 * If provided, the accept/reject CodeLens will be positioned near this line.
+	 * If not provided, it will be at the top of the file.
+	 */
+	targetLine?: number;
 }
 
 /**
@@ -122,4 +128,22 @@ export interface ShowDiffPreviewParams {
  */
 export namespace ShowDiffPreviewRequest {
 	export const type = new RequestType<ShowDiffPreviewParams, boolean, void>("phpcs/showDiffPreview");
+}
+
+/**
+ * The parameters for the save document notification.
+ */
+export interface SaveDocumentParams {
+	/**
+	 * The document URI to save.
+	 */
+	uri: string;
+}
+
+/**
+ * Notification sent from the server to the client to request saving a document.
+ * The client should save the document if the phpcbfSaveOnFix setting is enabled.
+ */
+export namespace SaveDocumentNotification {
+	export const type = new NotificationType<SaveDocumentParams>("phpcs/saveDocument");
 }

--- a/phpcs/src/protocol.ts
+++ b/phpcs/src/protocol.ts
@@ -6,6 +6,7 @@
 
 import {
 	NotificationType,
+	RequestType,
 	TextDocumentIdentifier
 } from "vscode-languageclient/node";
 
@@ -51,4 +52,74 @@ export interface DidEndValidateTextDocumentParams {
  */
 export namespace DidEndValidateTextDocumentNotification {
 	export const type = new NotificationType<DidEndValidateTextDocumentParams>("textDocument/didEndValidate");
+}
+
+/**
+ * The parameters sent in a did start fix text document notification
+ */
+export interface DidStartFixTextDocumentParams {
+	/**
+	 * The document on which fixing started.
+	 */
+	textDocument: TextDocumentIdentifier;
+}
+
+/**
+ * The document start fix notification is sent from the server to the client to signal
+ * the start of PHPCBF fixing on a text document.
+ */
+export namespace DidStartFixTextDocumentNotification {
+	export const type = new NotificationType<DidStartFixTextDocumentParams>("textDocument/didStartFix");
+}
+
+/**
+ * The parameters sent in a did end fix text document notification
+ */
+export interface DidEndFixTextDocumentParams {
+	/**
+	 * The document on which fixing ended.
+	 */
+	textDocument: TextDocumentIdentifier;
+	/**
+	 * Whether the document was successfully fixed.
+	 */
+	fixed: boolean;
+	/**
+	 * Error message if fixing failed.
+	 */
+	error?: string;
+}
+
+/**
+ * The document end fix notification is sent from the server to the client to signal
+ * the end of PHPCBF fixing on a text document.
+ */
+export namespace DidEndFixTextDocumentNotification {
+	export const type = new NotificationType<DidEndFixTextDocumentParams>("textDocument/didEndFix");
+}
+
+/**
+ * The parameters for the show diff preview request.
+ */
+export interface ShowDiffPreviewParams {
+	/**
+	 * The document URI.
+	 */
+	uri: string;
+	/**
+	 * The original content before fixes.
+	 */
+	originalContent: string;
+	/**
+	 * The fixed content after PHPCBF.
+	 */
+	fixedContent: string;
+}
+
+/**
+ * Request sent from the server to the client to show a diff preview.
+ * The client should display the diff and return true if the user accepts the changes.
+ */
+export namespace ShowDiffPreviewRequest {
+	export const type = new RequestType<ShowDiffPreviewParams, boolean, void>("phpcs/showDiffPreview");
 }

--- a/phpcs/src/protocol.ts
+++ b/phpcs/src/protocol.ts
@@ -99,6 +99,36 @@ export namespace DidEndFixTextDocumentNotification {
 }
 
 /**
+ * Represents a diff hunk for preview display.
+ */
+export interface PreviewDiffHunk {
+	/**
+	 * 0-indexed starting line in the original file.
+	 */
+	originalStart: number;
+	/**
+	 * Number of lines removed from the original.
+	 */
+	originalLength: number;
+	/**
+	 * 0-indexed starting line in the modified file.
+	 */
+	modifiedStart: number;
+	/**
+	 * Number of lines added in the modified file.
+	 */
+	modifiedLength: number;
+	/**
+	 * The original lines being removed.
+	 */
+	originalLines: string[];
+	/**
+	 * The new lines being added.
+	 */
+	modifiedLines: string[];
+}
+
+/**
  * The parameters for the show diff preview request.
  */
 export interface ShowDiffPreviewParams {
@@ -120,6 +150,11 @@ export interface ShowDiffPreviewParams {
 	 * If not provided, it will be at the top of the file.
 	 */
 	targetLine?: number;
+	/**
+	 * The diff hunks representing individual changes.
+	 * Each hunk can be accepted or rejected individually.
+	 */
+	hunks?: PreviewDiffHunk[];
 }
 
 /**

--- a/phpcs/src/settings.ts
+++ b/phpcs/src/settings.ts
@@ -26,4 +26,6 @@ export interface PhpcsSettings {
 	phpcbfEnable: boolean;
 	phpcbfExecutablePath: string | null;
 	phpcbfOnSave: boolean;
+	phpcbfShowDiff: boolean;
+	phpcbfTimeout: number;
 }

--- a/phpcs/src/settings.ts
+++ b/phpcs/src/settings.ts
@@ -27,6 +27,5 @@ export interface PhpcsSettings {
 	phpcbfExecutablePath: string | null;
 	phpcbfOnSave: boolean;
 	phpcbfSaveOnFix: boolean;
-	phpcbfShowDiff: boolean;
 	phpcbfTimeout: number;
 }

--- a/phpcs/src/settings.ts
+++ b/phpcs/src/settings.ts
@@ -26,6 +26,7 @@ export interface PhpcsSettings {
 	phpcbfEnable: boolean;
 	phpcbfExecutablePath: string | null;
 	phpcbfOnSave: boolean;
+	phpcbfSaveOnFix: boolean;
 	phpcbfShowDiff: boolean;
 	phpcbfTimeout: number;
 }

--- a/phpcs/src/status.ts
+++ b/phpcs/src/status.ts
@@ -19,6 +19,8 @@ export class PhpcsStatus {
 	private documents: string[] = [];
 	private processing: number = 0;
 	private buffered: number = 0;
+	private fixingDocuments: string[] = [];
+	private fixing: number = 0;
 	private spinnerIndex = 0;
 	private spinnerSequence: string[] = ["|", "/", "-", "\\"];
 	private timer: Timer;
@@ -45,23 +47,58 @@ export class PhpcsStatus {
 		if (index !== undefined) {
 			this.documents.slice(index, 1);
 		}
-		if (this.processing === 0) {
+		if (this.processing === 0 && this.fixing === 0) {
 			this.getTimer().stop();
 			this.getStatusBarItem().hide();
 			this.updateStatusText();
 		}
 	}
 
+	public startFixing(uri: string): void {
+		this.channel.appendLine('[PHPCBF] > ' + uri);
+		this.fixingDocuments.push(uri);
+		this.fixing += 1;
+		this.getTimer().start();
+		this.getStatusBarItem().show();
+	}
+
+	public endFixing(uri: string, fixed: boolean): void {
+		this.fixing -= 1;
+		const index = this.fixingDocuments.indexOf(uri);
+		if (index !== -1) {
+			this.fixingDocuments.splice(index, 1);
+		}
+		if (fixed) {
+			this.channel.appendLine('[PHPCBF] Fixed: ' + uri);
+		}
+		if (this.fixing === 0 && this.processing === 0) {
+			this.getTimer().stop();
+			this.getStatusBarItem().hide();
+		}
+		this.updateStatusText();
+	}
+
 	private updateStatusText(): void {
 		let statusBar = this.getStatusBarItem();
+
+		// Prioritize showing fixing status if PHPCBF is running
+		if (this.fixing > 0) {
+			let spinner = this.getNextSpinnerChar();
+			statusBar.text =
+				`$(wrench) PHPCBF fixing ${this.fixing} file`
+				+ ((this.fixing === 1) ? '' : 's')
+				+ ` ${spinner}`;
+			return;
+		}
+
 		let count = this.processing;
 		if (count > 0) {
 			let spinner = this.getNextSpinnerChar();
 			statusBar.text =
 				`$(eye) phpcs is linting ${count} document`
 				+ ((count === 1) ? '' : 's')
-				+ (this.buffered > 0 ? `(${this.buffered} in buffer)` : '')
-				+ `${spinner}`;
+				+ (this.buffered > 0 ? ` (${this.buffered} in buffer)` : '')
+				+ ` ${spinner}`;
 		} else if (this.buffered > 0) {
 			statusBar.text = `$(eye) phpcs keeps ${this.buffered} documents in buffer`;
 		}

--- a/phpcs/src/status.ts
+++ b/phpcs/src/status.ts
@@ -44,8 +44,8 @@ export class PhpcsStatus {
 		this.processing -= 1;
 		this.buffered = buffered;
 		let index = this.documents.indexOf(uri);
-		if (index !== undefined) {
-			this.documents.slice(index, 1);
+		if (index !== -1) {
+			this.documents.splice(index, 1);
 		}
 		if (this.processing === 0 && this.fixing === 0) {
 			this.getTimer().stop();

--- a/phpcs/src/strings.ts
+++ b/phpcs/src/strings.ts
@@ -30,6 +30,12 @@ export class StringResources {
 	static readonly PhpcbfCancelled: string = 'PHPCBF cancelled. Fixed {0} of {1} files.';
 	static readonly PhpcbfFixedWithFailures: string = 'PHPCBF: Fixed {0} files, {1} failed.';
 	static readonly PhpcbfFixedSuccess: string = 'PHPCBF: Successfully processed {0} files.';
+
+	// Diff preview
+	static readonly PhpcbfDiffApplyQuestion: string = 'Apply PHPCBF fixes?';
+	static readonly PhpcbfDiffApplyQuestionWithStats: string = 'Apply PHPCBF fixes? ({0} additions, {1} deletions)';
+	static readonly PhpcbfDiffApply: string = 'Apply';
+	static readonly PhpcbfDiffCancel: string = 'Cancel';
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR implements the PHPCBF post-v1 enhancements tracked in #18.

- **Inline diff preview**: "Preview fixes" action shows inline decorations with per-hunk Accept/Reject CodeLens actions
- **True single-issue fix**: "Fix only this issue" action applies only the relevant hunk for a specific diagnostic
- **Auto-save on fix**: New `phpcs.phpcbfSaveOnFix` setting to automatically save after applying fixes
- **Incremental preview**: After accepting a single fix, remaining fixes are automatically previewed

## Changes

### New Features
- Per-hunk inline diff preview with CodeLens actions (Accept, Accept all, Reject, Cancel)
- Automatic preview refresh after accepting individual fixes
- Document auto-save after each accepted fix (when `phpcbfSaveOnFix` enabled)

### Bug Fixes
- Fix `phpcbfSaveOnFix` setting not being passed to the language server
- Fix decorations not clearing immediately when accepting preview hunks

### Refactoring
- Remove obsolete `phpcs.phpcbfShowDiff` and `phpcs.phpcbfDiffInline` settings (replaced by the new inline preview)
- Update README and ROADMAP documentation

## Test plan

- [x] Open a PHP file with multiple fixable issues
- [x] Use "Preview fixes" from Quick Fix menu
- [x] Verify inline decorations appear with CodeLens actions
- [x] Click "Accept" on a single hunk - verify it applies and shows remaining previews
- [x] Click "Accept all" - verify all remaining fixes are applied
- [x] Click "Reject" - verify the hunk is removed from preview
- [x] Click "Cancel" - verify no changes are applied
- [x] Enable `phpcs.phpcbfSaveOnFix` and verify document saves after fixes

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fix single issues via quick fixes and preview fixes with inline per-hunk accept/reject UI (falls back to a diff editor)
  * Preview diff view and virtual preview documents for inspecting fixes
  * New commands to preview and apply fixes; UX notifications for fix start/end

* **Settings**
  * Optional auto-save after applying fixes via new phpcbfSaveOnFix setting

* **Status / UX**
  * Status bar shows active fixing progress

* **Documentation**
  * README PHPCBF integration section and updated roadmap

* **Tests**
  * Added comprehensive tests for diffing, hunk correlation, selective application, and code actions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->