### PR TITLE
fix: tolerate PHP notices preceding phpcs output

### DIFF
--- a/phpcs-server/src/fixer-utils.ts
+++ b/phpcs-server/src/fixer-utils.ts
@@ -386,7 +386,9 @@ export function createTimeoutResult(fileText: string, errorMessage: string): Fix
  * @returns The version string (e.g., '3.7.2') or null if not found
  */
 export function parseVersionString(output: string): string | null {
-	const versionPattern = /^PHP_CodeSniffer version (\d+\.\d+\.\d+)/i;
+	// Multiline flag: PHP notices (e.g. deprecation warnings) emitted by the
+	// project's own code can precede the version line (issue #31).
+	const versionPattern = /^PHP_CodeSniffer version (\d+\.\d+\.\d+)/im;
 	const match = output.match(versionPattern);
 	return match ? match[1] : null;
 }

--- a/phpcs-server/src/linter-utils.ts
+++ b/phpcs-server/src/linter-utils.ts
@@ -140,6 +140,18 @@ export function parsePhpcsOutput(text: string, context?: PhpcsExecutionContext):
 	try {
 		return JSON.parse(text) as PhpcsParseResult;
 	} catch (error) {
+		// PHP notices (e.g. deprecation warnings) emitted by the project's own
+		// code can precede the JSON report on stdout — retry from the first
+		// opening brace (issue #31).
+		const jsonStart = text.indexOf('{');
+		if (jsonStart > 0) {
+			try {
+				return JSON.parse(text.slice(jsonStart)) as PhpcsParseResult;
+			} catch {
+				// Fall through to the error handling below.
+			}
+		}
+
 		let errorMessage: string;
 
 		if (text.length === 0) {

--- a/phpcs-server/src/linter.ts
+++ b/phpcs-server/src/linter.ts
@@ -95,7 +95,9 @@ export class PhpcsLinter {
 
 			let result: Buffer = cp.execSync(`"${executablePath}" --version`);
 
-			const versionPattern: RegExp = /^PHP_CodeSniffer version (\d+\.\d+\.\d+)/i;
+			// Multiline flag: PHP notices (e.g. deprecation warnings) emitted by the
+			// project's own code can precede the version line (issue #31).
+			const versionPattern: RegExp = /^PHP_CodeSniffer version (\d+\.\d+\.\d+)/im;
 			const versionMatches = result.toString().match(versionPattern);
 
 			if (versionMatches === null) {

--- a/phpcs-server/src/linter.ts
+++ b/phpcs-server/src/linter.ts
@@ -34,6 +34,8 @@ import {
 	PhpcsExecutionContext,
 } from "./linter-utils";
 
+import { parseVersionString } from "./fixer-utils";
+
 // Re-export for backward compatibility
 export { FATAL_ERROR_PATTERN } from "./linter-utils";
 
@@ -95,16 +97,12 @@ export class PhpcsLinter {
 
 			let result: Buffer = cp.execSync(`"${executablePath}" --version`);
 
-			// Multiline flag: PHP notices (e.g. deprecation warnings) emitted by the
-			// project's own code can precede the version line (issue #31).
-			const versionPattern: RegExp = /^PHP_CodeSniffer version (\d+\.\d+\.\d+)/im;
-			const versionMatches = result.toString().match(versionPattern);
+			const executableVersion = parseVersionString(result.toString());
 
-			if (versionMatches === null) {
+			if (executableVersion === null) {
 				throw new Error(SR.InvalidVersionStringError);
 			}
 
-			const executableVersion = versionMatches[1];
 			return new PhpcsLinter(executablePath, executableVersion);
 
 		} catch (error: unknown) {

--- a/phpcs-server/test/fixer-utils.test.ts
+++ b/phpcs-server/test/fixer-utils.test.ts
@@ -436,6 +436,16 @@ suite('Fixer Utils', () => {
 			assert.strictEqual(version, null);
 		});
 
+		test('should parse version preceded by PHP deprecation notices (issue #31)', () => {
+			const polluted = [
+				'PHP Deprecated:  DI\\create(): Implicitly marking parameter $className as nullable is deprecated, the explicit nullable type must be used instead in /project/vendor/php-di/php-di/src/functions.php on line 35',
+				'',
+				'Deprecated: DI\\create(): Implicitly marking parameter $className as nullable is deprecated, the explicit nullable type must be used instead in /project/vendor/php-di/php-di/src/functions.php on line 35',
+				'PHP_CodeSniffer version 3.12.0 (stable) by Squiz and PHPCSStandards',
+			].join('\n');
+			assert.strictEqual(parseVersionString(polluted), '3.12.0');
+		});
+
 		test('should parse version with extra text', () => {
 			const version = parseVersionString('PHP_CodeSniffer version 3.9.1 (dev) by PHPCSStandards\nUsage: phpcs [options]');
 			assert.strictEqual(version, '3.9.1');

--- a/phpcs-server/test/linter-utils.test.ts
+++ b/phpcs-server/test/linter-utils.test.ts
@@ -110,6 +110,20 @@ suite('Linter Utils', () => {
 			assert.deepStrictEqual(result.files, {});
 		});
 
+		test('should parse JSON preceded by PHP deprecation notices (issue #31)', () => {
+			const json = '{"totals":{"errors":1,"warnings":0},"files":{"/path/file.php":{"errors":1,"warnings":0,"messages":[]}}}';
+			const polluted = 'Deprecated: DI\\create(): Implicitly marking parameter $className as nullable is deprecated in /project/vendor/php-di/php-di/src/functions.php on line 35\n' + json;
+			const result = parsePhpcsOutput(polluted);
+			assert.ok(result.files['/path/file.php']);
+		});
+
+		test('should still throw when output contains a brace but no valid JSON', () => {
+			assert.throws(
+				() => parsePhpcsOutput('Deprecated: something {broken'),
+				(error: Error) => error.message.includes('invalid json')
+			);
+		});
+
 		test('should throw on invalid JSON with raw output preview', () => {
 			const invalidInput = 'this is not valid json';
 			assert.throws(

--- a/phpcs-server/test/linter.test.ts
+++ b/phpcs-server/test/linter.test.ts
@@ -10,6 +10,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as semver from 'semver';
 import { FATAL_ERROR_PATTERN, PhpcsLinter } from '../src/linter';
+import { parseVersionString } from '../src/fixer-utils';
 import { transformIgnorePattern, isIgnorePatternMatch } from '../src/linter-utils';
 
 /**
@@ -198,13 +199,8 @@ suite('Linter Version Handling', () => {
 	 * Test version string parsing (from --version output)
 	 */
 	suite('Version string parsing', () => {
-		// Mirrors the pattern in PhpcsLinter.create(); keep the flags in sync.
-		const versionPattern: RegExp = /^PHP_CodeSniffer version (\d+\.\d+\.\d+)/im;
-
-		const parseVersion = (output: string): string | null => {
-			const matches = output.match(versionPattern);
-			return matches ? matches[1] : null;
-		};
+		// Exercises the shared parseVersionString used by PhpcsLinter.create().
+		const parseVersion = parseVersionString;
 
 		test('should parse v3.7.2 version string', () => {
 			const output = 'PHP_CodeSniffer version 3.7.2 (stable) by Squiz (http://www.squiz.net)';

--- a/phpcs-server/test/linter.test.ts
+++ b/phpcs-server/test/linter.test.ts
@@ -5,8 +5,11 @@
 'use strict';
 
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import * as semver from 'semver';
-import { FATAL_ERROR_PATTERN } from '../src/linter';
+import { FATAL_ERROR_PATTERN, PhpcsLinter } from '../src/linter';
 import { transformIgnorePattern, isIgnorePatternMatch } from '../src/linter-utils';
 
 /**
@@ -195,7 +198,8 @@ suite('Linter Version Handling', () => {
 	 * Test version string parsing (from --version output)
 	 */
 	suite('Version string parsing', () => {
-		const versionPattern: RegExp = /^PHP_CodeSniffer version (\d+\.\d+\.\d+)/i;
+		// Mirrors the pattern in PhpcsLinter.create(); keep the flags in sync.
+		const versionPattern: RegExp = /^PHP_CodeSniffer version (\d+\.\d+\.\d+)/im;
 
 		const parseVersion = (output: string): string | null => {
 			const matches = output.match(versionPattern);
@@ -229,6 +233,68 @@ suite('Linter Version Handling', () => {
 
 		test('should return null for empty output', () => {
 			assert.strictEqual(parseVersion(''), null);
+		});
+	});
+
+	/**
+	 * Test PhpcsLinter.create() version detection against fake executables,
+	 * including output polluted by PHP deprecation notices (issue #31).
+	 */
+	suite('PhpcsLinter.create version detection', () => {
+		const DEPRECATION_LINES = [
+			'PHP Deprecated:  DI\\create(): Implicitly marking parameter $className as nullable is deprecated, the explicit nullable type must be used instead in /project/vendor/php-di/php-di/src/functions.php on line 35',
+			'',
+			'Deprecated: DI\\create(): Implicitly marking parameter $className as nullable is deprecated, the explicit nullable type must be used instead in /project/vendor/php-di/php-di/src/functions.php on line 35',
+		];
+		const VERSION_LINE = 'PHP_CodeSniffer version 3.12.0 (stable) by Squiz and PHPCSStandards';
+
+		let tmpDir: string;
+
+		setup(() => {
+			tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'phpcs-fake-executable-'));
+		});
+
+		teardown(() => {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		});
+
+		/**
+		 * Create a fake phpcs executable that prints the given lines on any invocation.
+		 */
+		function makeFakeExecutable(lines: string[]): string {
+			if (process.platform === 'win32') {
+				const file = path.join(tmpDir, 'fake-phpcs.cmd');
+				const body = ['@echo off', ...lines.map(line => (line === '' ? 'echo.' : `echo ${line}`))].join('\r\n');
+				fs.writeFileSync(file, body);
+				return file;
+			}
+			const file = path.join(tmpDir, 'fake-phpcs');
+			// printf '%s\n' (not echo): some /bin/sh implementations (dash) interpret
+			// backslash escapes like \c in echo arguments, truncating the output.
+			const body = ['#!/bin/sh', ...lines.map(line => `printf '%s\\n' '${line}'`)].join('\n');
+			fs.writeFileSync(file, body);
+			fs.chmodSync(file, 0o755);
+			return file;
+		}
+
+		test('should detect the version from clean output', async () => {
+			const executable = makeFakeExecutable([VERSION_LINE]);
+			const linter = await PhpcsLinter.create(executable);
+			assert.ok(linter instanceof PhpcsLinter);
+		});
+
+		test('should detect the version when preceded by PHP deprecation notices (issue #31)', async () => {
+			const executable = makeFakeExecutable([...DEPRECATION_LINES, VERSION_LINE]);
+			const linter = await PhpcsLinter.create(executable);
+			assert.ok(linter instanceof PhpcsLinter);
+		});
+
+		test('should reject when the output contains no version line', async () => {
+			const executable = makeFakeExecutable(['No version information here']);
+			await assert.rejects(
+				() => PhpcsLinter.create(executable),
+				(error: Error) => error.message.includes('Unable to locate phpcs')
+			);
 		});
 	});
 

--- a/phpcs/CHANGELOG.md
+++ b/phpcs/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolved ruleset file (or the `phpcs.standard` setting)
   ([#21](https://github.com/JohnRDOrazio/vscode-phpcs/issues/21))
 
+### Fixed
+
+- **PHP deprecation notices no longer break the extension**: version detection
+  for phpcs/phpcbf and JSON report parsing now tolerate PHP notices (e.g.
+  deprecation warnings from the project's own dependencies) printed before the
+  expected output
+  ([#31](https://github.com/JohnRDOrazio/vscode-phpcs/issues/31))
+
 ## [1.2.3] - 2026-01-10
 
 ### Added


### PR DESCRIPTION
Fixes #31

## Problem

PHP notices (e.g. deprecation warnings from a project's own dependencies, like php-di on PHP 8.4 with `display_errors` on) are printed to stdout **before** phpcs's own output. This broke the extension in three places:

1. **`PhpcsLinter.create()`** — the version regex `/^PHP_CodeSniffer version .../i` was anchored to the start of the *entire* output, so any preceding output caused "Unable to locate phpcs. Invalid version string encountered!" (the reported failure — reproduced with a fake phpcs mimicking the reporter's exact output).
2. **`parseVersionString()`** (phpcbf version detection) — identical anchored regex, same failure for PHPCBF.
3. **`parsePhpcsOutput()`** — raw `JSON.parse(stdout)` of the lint report; the same notices prepended to the JSON would have produced "invalid json" on every lint once version detection was fixed.

## Fix

- Add the multiline (`m`) flag to both version regexes so the version line matches at any line start.
- In `parsePhpcsOutput()`, when the initial parse fails, retry from the first opening brace; if that also fails, the existing error handling (with output preview) is unchanged.

## Testing

- Unit tests for all three functions using the polluted-output fixture from the reproduction (the exact php-di deprecation lines from #31).
- End-to-end test: `PhpcsLinter.create()` against a fake phpcs executable that prints deprecation notices before the version line (cross-platform: `.cmd` on Windows, `printf`-based sh script elsewhere), plus clean-output and no-version-line cases.
- Full suite: 236 server + 1 client tests passing; negative paths preserved (garbage output containing a brace still throws "invalid json").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with PHP_CodeSniffer output that includes deprecation notices or other messages before expected results.
  * Version detection now succeeds when notices precede the reported version.
  * JSON reports can now be parsed when valid data follows preceding notices.
  * Invalid output continues to produce an appropriate error.

* **Documentation**
  * Updated the changelog with these compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->