### PR TITLE
chore(release): 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-phpcs",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-phpcs",
-      "version": "1.2.3",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-phpcs",
   "description": "PHP CodeSniffer for Visual Studio Code",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "author": "Ioannis Kappas",
   "publisher": "johnrdorazio",
   "contributors": [

--- a/phpcs-server/package-lock.json
+++ b/phpcs-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-phpcs-server",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-phpcs-server",
-      "version": "1.2.3",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.6",

--- a/phpcs-server/package.json
+++ b/phpcs-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-phpcs-server",
   "description": "PHP Code Sniffer server.",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "author": "Ioannis Kappas",
   "publisher": "johnrdorazio",
   "contributors": [

--- a/phpcs/CHANGELOG.md
+++ b/phpcs/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the "vscode-phpcs" extension will be documented in this f
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] - 2026-07-18
 
 ### Added
 

--- a/phpcs/package-lock.json
+++ b/phpcs/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-phpcs",
-	"version": "1.2.3",
+	"version": "1.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-phpcs",
-			"version": "1.2.3",
+			"version": "1.3.0",
 			"license": "MIT",
 			"dependencies": {
 				"vscode-languageclient": "^9.0.1"

--- a/phpcs/package.json
+++ b/phpcs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "vscode-phpcs",
 	"description": "PHP CodeSniffer for Visual Studio Code",
-	"version": "1.2.3",
+	"version": "1.3.0",
 	"author": "Ioannis Kappas",
 	"publisher": "johnrdorazio",
 	"contributors": [


### PR DESCRIPTION
## Release 1.3.0

Bumps all package versions (root, `phpcs`, `phpcs-server` + lockfiles) to **1.3.0** and dates the changelog's Unreleased section as `[1.3.0] - 2026-07-18`.

### What ships in this release

**Added**
- Resolved-standard visibility: lint logs, PHPCBF logs, and a status bar item showing the standard in use, clickable to open the ruleset (#21)
- Document formatter support: the extension registers as a PHP formatter, enabling `editor.defaultFormatter`, **Format Document**, and `editor.formatOnSave` via PHPCBF (#23)

**Fixed**
- PHP deprecation notices no longer break version detection or JSON report parsing (#31)
- No more error toast when saving/fixing files excluded by the PHPCS ruleset under PHPCS v4 — thanks @Kwaadpepper (#29, #30)

**Security**
- All 27 Dependabot alerts resolved across the dev/build dependency tree (#27, #28, #33, #34)

### After merge

Tagging the merge commit `1.3.0` triggers `publish.yml` (tests → Open VSX → VS Marketplace, with tag/package version validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)