### PR TITLE
ci: Dependabot with grouped updates, auto-merge and SHA-pinned actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,84 @@
+# Dependabot configuration for vscode-phpcs.
+#
+# Unlike the sibling PHP repositories there is no `target-branch` here: this
+# repository's default branch is `develop`, which is also the branch releases
+# are cut from, so version updates belong there directly.
+#
+# Minor and patch updates are grouped into a single pull request per ecosystem
+# and auto-merged once the required checks on `develop` pass (see
+# .github/workflows/dependabot-auto-merge.yml). Major updates always fall out
+# of the groups into their own pull request and are always reviewed by hand.
+
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    # Wait 7 days before proposing updates to newly published versions, to
+    # reduce exposure to a compromised or yanked release (supply-chain).
+    cooldown:
+      default-days: 7
+    labels:
+      - 'dependencies'
+      - 'github-actions'
+    commit-message:
+      prefix: 'ci'
+    # The workflows pin actions by commit SHA with the version in a trailing
+    # comment; Dependabot rewrites both together, which is the whole reason the
+    # pins stay readable.
+    groups:
+      github-actions:
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  - package-ecosystem: 'npm'
+    # Three independent installs, none of them npm workspaces: the repository
+    # root (build, test and lint tooling), the VS Code extension client, and the
+    # language server. Listing them together lets a single grouped pull request
+    # span all three.
+    directories:
+      - '/'
+      - '/phpcs'
+      - '/phpcs-server'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 7
+    # Dependabot's default ceiling on open version-update PRs is five. Once it
+    # is reached Dependabot stops opening new ones — silently, with nothing to
+    # indicate an update was withheld — so a group can be starved by unrelated
+    # PRs sitting in review. Ten leaves headroom for the groups below plus the
+    # major-version PRs and a security update or two.
+    open-pull-requests-limit: 10
+    labels:
+      - 'dependencies'
+      - 'javascript'
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+    # Groups are matched in the order they are declared — a dependency joins the
+    # FIRST group whose patterns match — so the specific group must precede the
+    # catch-all.
+    groups:
+      # `@types/vscode` must never move ahead of `engines.vscode` in
+      # phpcs/package.json: vsce refuses to package an extension whose types are
+      # newer than the engine it declares. The `lint` job runs `vsce package`
+      # precisely to catch that, so such a bump fails a required check and is
+      # left unmerged. It still needs its own pull request: inside the group
+      # below it would drag every other weekly minor and patch down with it.
+      # Raising it means deciding to raise the minimum supported VS Code version
+      # too, which is a judgement call, not a dependency bump.
+      types-vscode:
+        patterns:
+          - '@types/vscode'
+      # One pull request per week covering every minor and patch bump across all
+      # three directories, which also keeps the devDependencies shared between
+      # them (mocha, tsx, typescript, …) on the same version everywhere.
+      npm-minor-patch:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -59,16 +59,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup PHP ${{ matrix.php-version }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: ${{ matrix.php-version }}
           tools: composer
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -106,10 +106,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: '8.3'
           tools: composer
@@ -123,7 +123,7 @@ jobs:
           phpcbf --version
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -138,7 +138,7 @@ jobs:
         run: npm run test:server:coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./phpcs-server/coverage
@@ -150,10 +150,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,17 @@ jobs:
       - name: Lint markdown
         run: npm run lint:md
 
+      - name: Bundle
+        run: npm run bundle
+
+      # `vsce package` is the only check that catches `@types/vscode` drifting
+      # ahead of `engines.vscode` in phpcs/package.json — it refuses to package
+      # when the types are newer than the engine the extension declares. Without
+      # this step the mismatch would first surface in the publish workflow, on a
+      # tag, after the offending dependency bump had already been merged.
+      - name: Verify the extension packages
+        run: npm run package
+
   # The single status check that branch protection should require from this
   # workflow.
   #

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,44 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
+      # --auto enables auto-merge rather than merging on the spot: the pull
+      # request lands only once the branch protection on `develop` is satisfied,
+      # which today means the full CI matrix plus `coverage`, `lint` and
+      # `security`. That gate is what makes this safe; with no required check
+      # the pull request would be mergeable on arrival and this would merge it
+      # immediately, CI result notwithstanding.
+      #
+      # Grouped pull requests report the highest update-type they contain, so a
+      # group holding a major is correctly excluded. The npm groups already
+      # exclude majors by construction.
+      #
+      # GITHUB_TOKEN cannot merge a pull request that modifies .github/workflows
+      # (a hard GitHub restriction, not something the `permissions:` block above
+      # can grant), which is exactly what github-actions ecosystem PRs do. If a
+      # WORKFLOW_AUTOMERGE_PAT Dependabot secret (fine-grained, repo-scoped,
+      # Workflows: write) is configured it is used instead; when it is absent —
+      # as it is today — action bumps simply wait for a manual merge and every
+      # other update still flows.
+      - name: Auto-merge minor and patch updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_AUTOMERGE_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,16 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: '8.3'
           tools: composer
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -55,14 +55,14 @@ jobs:
           echo "Version validation passed: $TAG_VERSION"
 
       - name: Publish to Open VSX Registry
-        uses: HaaLeo/publish-vscode-extension@v2
+        uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # v2.0.0
         id: publishToOpenVSX
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
           packagePath: ./phpcs
 
       - name: Publish to Visual Studio Marketplace
-        uses: HaaLeo/publish-vscode-extension@v2
+        uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # v2.0.0
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: 'npm'
@@ -30,7 +30,7 @@ jobs:
         run: npm ci
 
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@12140f4059e244892ae643824a95459a102120dd # master
         id: snyk
         continue-on-error: true
         env:
@@ -40,6 +40,6 @@ jobs:
 
       - name: Upload result to GitHub Code Scanning
         if: always() && hashFiles('snyk.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: snyk.sarif


### PR DESCRIPTION
Sets up Dependabot on the pattern of the sibling LiturgicalCalendar repositories, adapted to this repository's layout.

## Dependabot config

`.github/dependabot.yml` — weekly, with a 7 day `cooldown` on newly published versions to reduce exposure to a compromised or yanked release.

- **No `target-branch`.** Unlike the PHP repositories, `develop` is already the default branch here and is what releases are cut from, so updates belong there directly.
- **npm covers all three installs** via `directories: ["/", "/phpcs", "/phpcs-server"]`. They are not npm workspaces, so listing them together is what lets one grouped pull request span all three — which also keeps the devDependencies shared between them (`mocha`, `tsx`, `typescript`, …) on the same version everywhere.
- **Minor and patch are grouped** per ecosystem via `update-types: [minor, patch]`. Majors fall out of the groups into individual pull requests and stay manual.
- `open-pull-requests-limit: 10`, because Dependabot's default ceiling of five would let a group be starved silently by unrelated pull requests sitting in review.
- Commit prefixes `chore(deps)` and `ci(deps)` to match the repository's conventional-commit style.

## Auto-merge

`.github/workflows/dependabot-auto-merge.yml` — `dependabot/fetch-metadata` plus `gh pr merge --auto --merge`, skipping `version-update:semver-major`.

`--auto` is what makes this safe: the pull request lands only once branch protection on `develop` is satisfied, which today means the full build matrix, the PHPCS integration matrix, `coverage`, `lint` and `security`. Grouped pull requests report the highest update-type they contain, so a group holding a major is correctly excluded — and the npm groups exclude majors by construction anyway.

## Actions pinned to SHAs

Every action across `ci.yml`, `publish.yml` and `snyk.yml` was on a moving tag; each is now pinned to a commit SHA with the version in a trailing comment, which Dependabot rewrites as a pair.

The pins keep the major currently in use rather than jumping to the latest release, so behaviour is unchanged and Dependabot will raise the major bumps as reviewable pull requests. Every SHA was verified against its tag via the API. `snyk/actions/node` has no current release tag and was tracking `@master`, so it is pinned to that branch's present head.

## Packaging check in the lint job

`vsce` refuses to package an extension whose `@types/vscode` is newer than the `engines.vscode` it declares. Nothing in CI ran `vsce`, so an auto-merged `@types/vscode` bump would first have failed in the publish workflow, on a tag, well after the fact.

The `lint` job now bundles and packages. Verified locally: it passes on this tree, and exits 1 with `@types/vscode ^1.107.0 greater than engines.vscode ^1.106.3` when the types are raised. `@types/vscode` also gets its own Dependabot group so that such a failure does not hold back the rest of the weekly batch. The job keeps its `lint` name, since renaming it would silently drop it from the required checks.

## Labels

`dependencies` and `javascript` already existed; `github-actions` has been created on the repository.

## Follow-up, not in this PR

- **`WORKFLOW_AUTOMERGE_PAT`.** `GITHUB_TOKEN` cannot merge a pull request that touches `.github/workflows`, so the job prefers this secret and falls back when absent. Until it exists, github-actions bumps will need a manual merge; everything else flows. It must be created as a **Dependabot** secret, not an Actions one — Dependabot-triggered runs do not see Actions secrets — and the PAT needs Workflows: write alongside Contents and Pull requests.
- **`CODECOV_TOKEN` and `SNYK_TOKEN`** are Actions secrets, so Dependabot pull requests cannot see them. Both steps are non-fatal (`fail_ci_if_error: false`, `continue-on-error: true`) so the required checks still pass, but adding them as Dependabot secrets would give those pull requests real coverage and scan results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added scheduled automated updates for GitHub Actions and npm dependencies.
  * Added automatic merging for approved minor and patch dependency updates after checks pass.

* **Bug Fixes**
  * Improved release reliability by validating extension packaging during continuous integration.
  * Strengthened workflow security by pinning build, publishing, and security-scanning actions to verified revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->