### PR TITLE
fix(ci): patch PHPCS matrix for CVE-2026-67434 and stop branch protection drifting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,3 +163,38 @@ jobs:
 
       - name: Lint markdown
         run: npm run lint:md
+
+  # The single status check that branch protection should require from this
+  # workflow.
+  #
+  # Every other job here is a matrix job whose name embeds the PHPCS, PHP, Node
+  # and OS versions it runs against, so requiring those contexts directly means
+  # the protection rules have to be rewritten by hand on every bump. Worse, the
+  # failure mode is silent and total: a required context that stops reporting —
+  # because the version in its name changed — is never satisfied, so every pull
+  # request is blocked until someone notices the rule is stale. Requiring only
+  # this job leaves the matrix underneath free to change.
+  #
+  # `security`, in snyk.yml, is required separately: `needs` cannot reach across
+  # workflows, and that job's name is already static.
+  ci-required:
+    runs-on: ubuntu-latest
+    needs: [build, phpcs-integration, coverage, lint]
+    # Without `if: always()` this job is skipped whenever an upstream job fails,
+    # and branch protection counts a skipped check as a passing one — which
+    # would make the gate wave through exactly the failures it exists to catch.
+    if: always()
+
+    steps:
+      - name: Verify every upstream job succeeded
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "Upstream job results: $RESULTS"
+          for result in $RESULTS; do
+            if [ "$result" != "success" ]; then
+              echo "::error::CI did not pass — an upstream job reported '$result'"
+              exit 1
+            fi
+          done
+          echo "All upstream jobs succeeded."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        phpcs-version: ['3.10.3', '4.0.1']
+        # Both lines are held at or above the fix for CVE-2026-67434 (OS command
+        # injection, PHPCS < 3.13.6 and >= 4.0.0 < 4.0.2). Composer refuses to
+        # install a release covered by an advisory, so anything below these
+        # fails to resolve rather than installing something vulnerable.
+        phpcs-version: ['3.13.6', '4.0.4']
         php-version: ['8.1', '8.3']
         install-type: ['global', 'local']
         exclude:
           # PHPCS 4.x works best with PHP 8.3
-          - phpcs-version: '4.0.1'
+          - phpcs-version: '4.0.4'
             php-version: '8.1'
       fail-fast: false
 

--- a/docs/PHPCS_V4_ROADMAP.md
+++ b/docs/PHPCS_V4_ROADMAP.md
@@ -179,8 +179,8 @@ static readonly StderrDebugOutput: string = 'PHPCS debug output: {0}';
 - [x] Create test fixtures for PHPCS v4 output (version comparison logic tests in linter.test.ts)
 - [x] Add unit tests for STDERR handling with v4
 - [x] Add unit tests for new exit code handling
-- [x] Add integration tests with actual PHPCS v4 binary (CI runs tests against v3.10.3 and v4.0.1)
-- [x] Test backwards compatibility with PHPCS v3.x (CI matrix includes v3.10.3)
+- [x] Add integration tests with actual PHPCS v4 binary (CI runs tests against v3.13.6 and v4.0.4)
+- [x] Test backwards compatibility with PHPCS v3.x (CI matrix includes v3.13.6)
 
 **Test scenarios covered:**
 


### PR DESCRIPTION
CI has been failing on every new pull request since 2026-08-05. This unblocks it and removes the class of problem that the fix would otherwise have caused.

## The breakage

`composer require squizlabs/php_codesniffer:3.10.3` now fails to resolve:

```
Root composer.json requires squizlabs/php_codesniffer 3.10.3 ... found
squizlabs/php_codesniffer[3.10.3] but these were not loaded, because they
are affected by security advisories ("PKSA-rdkp-vv9z-mjkg")
```

That is **CVE-2026-67434**, OS command injection, published 2026-08-05, affecting `< 3.13.6` and `>= 4.0.0 < 4.0.2`. The matrix pinned `3.10.3` and `4.0.1` — both inside those ranges — and Composer refuses to install a release covered by an advisory rather than installing something vulnerable. All six integration jobs fail at the install step.

CI last ran green on `develop` on 2026-07-19, three weeks before the advisory landed, which is why nobody saw this until the next pull request went up.

The matrix now uses `3.13.6` and `4.0.4`, the current patched releases of each line. Both still satisfy the existing PHP matrix (`3.13.6` needs PHP >= 5.4, `4.0.4` needs >= 7.2), so the `4.x` on PHP 8.1 exclusion stays a project preference rather than a hard constraint, and is left alone.

## Why that bump would have broken everything

The required status checks on `develop` name every matrix job — `PHPCS 3.10.3 (global) / PHP 8.1` and fourteen others — so each one embeds a PHPCS, PHP, Node or OS version. Renaming the jobs leaves six required contexts that never report again, and a required context that never reports is never satisfied: **every pull request blocked, indefinitely, with nothing on the page explaining that the rule rather than the code is wrong.**

So the versions cannot be bumped without editing branch protection in the same breath — and that would be true again on the next bump, and the one after.

## The fix for the drift

A `ci-required` job that `needs` the other four and fails unless all of them succeeded. Branch protection requires that one stable context, and the matrix underneath is then free to change.

It runs `if: always()`. Without that it would be skipped whenever an upstream job failed — and branch protection treats a skipped check as a passing one, so the gate would wave through precisely the failures it exists to catch.

`security` (in `snyk.yml`) is still required separately: `needs` cannot reach across workflows, and that job's name is already static.

## Branch protection

Once `ci-required` reports green here, the required contexts on `develop` become just `ci-required` and `security`, replacing the fifteen version-bearing ones.

## Note on #43

[#43](https://github.com/JohnRDOrazio/vscode-phpcs/pull/43) (Dependabot setup) predates this and will be rebased once this merges. It is red for the same advisory, not for anything in its own diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)