### PR TITLE
ci: stop Dependabot proposing @types/vscode

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,21 +58,29 @@ updates:
     commit-message:
       prefix: 'chore'
       include: 'scope'
+    ignore:
+      # `@types/vscode` is pinned to `engines.vscode` in phpcs/package.json by
+      # hand, because bumping it is not a dependency update — it is a decision
+      # to raise the minimum VS Code version the extension will install on.
+      # vsce enforces the pairing and refuses to package when the types are
+      # newer than the declared engine, which the `lint` job catches (#45), so
+      # every such bump arrives as a red pull request that cannot be merged
+      # without also editing the manifest.
+      #
+      # There is nothing to gain by taking them. The client imports only
+      # long-stable API — window, workspace, commands, StatusBarItem, Uri,
+      # OutputChannel, ExtensionContext — and a survey of the 1.107…1.125
+      # release notes found no linting, diagnostics or code-action API added in
+      # that range. The one worthwhile addition, LSP 3.18, comes from
+      # vscode-languageclient 10, which itself declares `engines.vscode ^1.91.0`
+      # and so needs no change here at all.
+      #
+      # Raise both together, deliberately, if a newer API is ever wanted.
+      - dependency-name: '@types/vscode'
     # Groups are matched in the order they are declared — a dependency joins the
-    # FIRST group whose patterns match — so the specific group must precede the
+    # FIRST group whose patterns match — so any specific group must precede the
     # catch-all.
     groups:
-      # `@types/vscode` must never move ahead of `engines.vscode` in
-      # phpcs/package.json: vsce refuses to package an extension whose types are
-      # newer than the engine it declares. The `lint` job runs `vsce package`
-      # precisely to catch that, so such a bump fails a required check and is
-      # left unmerged. It still needs its own pull request: inside the group
-      # below it would drag every other weekly minor and patch down with it.
-      # Raising it means deciding to raise the minimum supported VS Code version
-      # too, which is a judgement call, not a dependency bump.
-      types-vscode:
-        patterns:
-          - '@types/vscode'
       # One pull request per week covering every minor and patch bump across all
       # three directories, which also keeps the devDependencies shared between
       # them (mocha, tsx, typescript, …) on the same version everywhere.


### PR DESCRIPTION
Closes the loop on [#45](https://github.com/JohnRDOrazio/vscode-phpcs/pull/45), which bumped `@types/vscode` 1.106.1 → 1.125.0 and failed `lint` with:

```
@types/vscode ^1.125.0 greater than engines.vscode ^1.106.3.
Either upgrade engines.vscode or use an older @types/vscode version
```

That is the packaging guard working exactly as intended — but it will keep happening every time a new `@types/vscode` ships, and each one needs a manual decision it cannot make for itself.

## Why ignore rather than take the bump

Bumping `@types/vscode` is not a dependency update. It is a decision to raise the minimum VS Code version the extension will install on, and `vsce` enforces the pairing, so the bump is inseparable from editing `engines.vscode` in the manifest.

Nothing in the range argues for making that decision now:

- The client imports only long-stable API — `window`, `workspace`, `commands`, `StatusBarItem`, `Uri`, `OutputChannel`, `ExtensionContext`. None of it postdates 1.106.
- The 1.107–1.125 release notes add no linting, diagnostics, code-action or formatting API. 1.110 and 1.115 add nothing relevant at all; 1.120's diff APIs (`workspace.getTextDiff`, custom editor diffs) are still *proposed* and unusable in a published extension.
- The one worthwhile addition, **LSP 3.18** in 1.125, ships via `vscode-languageclient@10` — which declares `engines.vscode: ^1.91.0`, *below* the current floor. It can be adopted without touching the engine at all.

So the engine bump costs compatibility (1.106 shipped 2025-11-12, 1.125 on 2026-06-17 — about seven months of hosts) and buys nothing.

## What changes

- `@types/vscode` added to `ignore` for the npm ecosystem.
- The `types-vscode` group is dropped, since it can no longer match anything.

The `vsce package` step in the `lint` job stays. It is now the backstop for a *manual* bump that forgets to move `engines.vscode` alongside it.

## Not in this PR

`vscode-languageclient` / `vscode-languageserver` v9 → v10 (LSP 3.18) is a real upgrade worth doing deliberately, with the PHPCS integration matrix exercised. Dependabot will raise it as a major in its own pull request, which the config already keeps out of auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)