### PR TITLE
chore(deps): upgrade to LSP 3.18 (languageclient/server 10.1.0)

### DIFF
--- a/phpcs-server/package-lock.json
+++ b/phpcs-server/package-lock.json
@@ -12,7 +12,7 @@
         "cross-spawn": "^7.0.6",
         "micromatch": "^4.0.8",
         "semver": "^7.8.5",
-        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver": "^10.1.0",
         "vscode-languageserver-textdocument": "^1.0.12",
         "vscode-uri": "^3.0.8"
       },
@@ -1715,34 +1715,34 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageserver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-10.1.0.tgz",
+      "integrity": "sha512-9gEWpXkYGXoqG7pBnE8O8hx/yP7+Aabn4+peQ3KDicQv6qunHSWyLTud3OF0w4S2+HfDD+5HqYKiXQW9HAU6mA==",
       "license": "MIT",
       "dependencies": {
-        "vscode-languageserver-protocol": "3.17.5"
+        "vscode-languageserver-protocol": "3.18.2"
       },
       "bin": {
         "installServerIntoExtension": "bin/installServerIntoExtension"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
       "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
+        "vscode-jsonrpc": "9.0.1",
+        "vscode-languageserver-types": "3.18.0"
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
@@ -1752,9 +1752,9 @@
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
       "license": "MIT"
     },
     "node_modules/vscode-uri": {

--- a/phpcs-server/package.json
+++ b/phpcs-server/package.json
@@ -30,7 +30,7 @@
     "cross-spawn": "^7.0.6",
     "micromatch": "^4.0.8",
     "semver": "^7.8.5",
-    "vscode-languageserver": "^9.0.1",
+    "vscode-languageserver": "^10.1.0",
     "vscode-languageserver-textdocument": "^1.0.12",
     "vscode-uri": "^3.0.8"
   },

--- a/phpcs-server/test/linter-utils.test.ts
+++ b/phpcs-server/test/linter-utils.test.ts
@@ -330,7 +330,11 @@ suite('Linter Utils', () => {
 				column: 1,
 			};
 			const diagnostic = createDiagnosticFromMessage(document, message, true);
-			assert.ok(diagnostic.message.includes('(Test.Rule)'));
+			// LSP 3.18 widened Diagnostic.message to `string | MarkupContent`.
+			// We only ever emit a plain string, so assert that before reading it
+			// as one — the narrowing is the point, not a cast to silence tsc.
+			assert.strictEqual(typeof diagnostic.message, 'string');
+			assert.ok((diagnostic.message as string).includes('(Test.Rule)'));
 		});
 
 		test('should set Warning severity for WARNING type', () => {

--- a/phpcs/package-lock.json
+++ b/phpcs/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.3.0",
 			"license": "MIT",
 			"dependencies": {
-				"vscode-languageclient": "^9.0.1"
+				"vscode-languageclient": "^10.1.0"
 			},
 			"devDependencies": {
 				"@types/vscode": "^1.106.0",
@@ -68,18 +68,24 @@
 			}
 		},
 		"node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"license": "MIT"
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
-			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/chalk": {
@@ -311,15 +317,18 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-			"license": "ISC",
+			"version": "10.2.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+			"integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^5.0.8"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/ms": {
@@ -520,42 +529,49 @@
 			"license": "MIT"
 		},
 		"node_modules/vscode-jsonrpc": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+			"integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/vscode-languageclient": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
-			"integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.1.0.tgz",
+			"integrity": "sha512-XXRx6lqVitQy/oOLr9MfNYRG+MbQkhXkDaxbQMiKxEm8zZNfheRFUKNb8UYNh2stn9btl2wQM5wZFJjJvoc+jA==",
 			"license": "MIT",
 			"dependencies": {
-				"minimatch": "^5.1.0",
-				"semver": "^7.3.7",
-				"vscode-languageserver-protocol": "3.17.5"
+				"minimatch": "^10.2.5",
+				"semver": "^7.8.1",
+				"vscode-languageserver-protocol": "3.18.2",
+				"vscode-languageserver-textdocument": "1.0.13"
 			},
 			"engines": {
-				"vscode": "^1.82.0"
+				"vscode": "^1.91.0"
 			}
 		},
 		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.17.5",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+			"version": "3.18.2",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+			"integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
 			"license": "MIT",
 			"dependencies": {
-				"vscode-jsonrpc": "8.2.0",
-				"vscode-languageserver-types": "3.17.5"
+				"vscode-jsonrpc": "9.0.1",
+				"vscode-languageserver-types": "3.18.0"
 			}
 		},
+		"node_modules/vscode-languageserver-textdocument": {
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.13.tgz",
+			"integrity": "sha512-nx0ZHwMGIsVkzFG3/VLeJYBLTaFBRuNdGDvevvjuoayU5EOS2fEYazOhtCM3PI9ClMMg5igc0uwXtAq4tJj+Dw==",
+			"license": "MIT"
+		},
 		"node_modules/vscode-languageserver-types": {
-			"version": "3.17.5",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+			"integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
 			"license": "MIT"
 		}
 	}

--- a/phpcs/package.json
+++ b/phpcs/package.json
@@ -225,6 +225,6 @@
 		"@vscode/test-electron": "^2.4.1"
 	},
 	"dependencies": {
-		"vscode-languageclient": "^9.0.1"
+		"vscode-languageclient": "^10.1.0"
 	}
 }


### PR DESCRIPTION
Supersedes #67 and #69.

## Why these had to be combined

They are the client and server halves of **one** protocol upgrade, versioned in lockstep. Dependabot raised them as two independent pull requests because they live in different directories and it has no way to know they are coupled.

Merging either alone would put a v10 client against a v9 server — and neither PR's CI would have caught it, because each was tested against a `develop` where the other half was still v9.

## Breaking changes, checked against this codebase

| Change | Impact here |
|---|---|
| Libraries moved to the `exports` field, may require `module`/`moduleResolution: node16` | **None** — both tsconfigs already use `node16` |
| Custom log/trace channels must be `LogOutputChannel` | **None** — we pass neither; `status.ts`'s channel is its own, from `window.createOutputChannel` |
| `showDocument` middleware gained a required `CancellationToken` | **None** — our middleware implements only `workspace.configuration` |
| `Diagnostic.message` widened to `string \| MarkupContent` | **One test assertion** — see below |
| Release note mentions "NodeJS 22.13.14" | **None** — neither package declares `engines.node`; that refers to build-time types, so the Node 20 end of the runtime matrix is unaffected |

## The one real break

`Diagnostic.message` is now `string | MarkupContent`, so `.includes()` no longer typechecks. No production code reads `diagnostic.message`, and `createDiagnosticFromMessage` always builds a plain string.

Fixed by asserting the contract rather than casting the union away:

```ts
assert.strictEqual(typeof diagnostic.message, 'string');
assert.ok((diagnostic.message as string).includes('(Test.Rule)'));
```

The test now also pins that we emit plain strings, which it did not before.

## Verification

On Node 22.23.2: typecheck, bundle, 221 server unit tests, the client suite, and `vsce package` all pass. CI adds the PHPCS integration matrix against real 3.13.6 and 4.0.4 binaries.

Size cost of the protocol update: bundled server 292 KB → 312 KB, packaged extension 187 KB → 206 KB.

## ⚠️ What CI cannot tell us

**Nothing in the test suite exercises the client/server LSP handshake.** The server tests drive the linter directly, the integration tests drive real PHPCS, and the client suite is a single placeholder. So a green CI here does not prove the round trip still works across a protocol major.

This wants a smoke test in the Extension Development Host — open a PHP file with violations, confirm diagnostics appear, confirm the PHPCBF fix action and format-on-save still work — before it goes anywhere near a release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated language service components to newer versions for improved compatibility.
* **Tests**
  * Improved diagnostic validation to support the latest language server protocol typing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->