### PR TITLE
chore: move the runtime floor to Node 22 and pin @types/node to it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -77,6 +77,34 @@ updates:
       #
       # Raise both together, deliberately, if a newer API is ever wanted.
       - dependency-name: '@types/vscode'
+
+      # `@types/node` tracks the MINIMUM runtime we support, not the newest.
+      # That floor is the oldest VS Code we run on, because the language server
+      # executes in its extension host: 1.106.3 is Electron 37.7.0, which is
+      # Node 22.20.0. Typing against anything newer would let code compile
+      # against APIs that are simply absent on the runtime we claim to support,
+      # and unlike `@types/vscode` there is no vsce-style check to catch it.
+      #
+      # #64 proposed 26. Widening the CI matrix upward (22, 24, 26) is not an
+      # argument for it: the matrix is the range we support, and the types have
+      # to match its floor. Raise this only when the floor itself moves, which
+      # means raising engines.vscode first.
+      #
+      # Majors only — 22.x type fixes should keep flowing.
+      - dependency-name: '@types/node'
+        update-types:
+          - 'version-update:semver-major'
+
+      # TypeScript 7 (the native port) cannot be adopted yet: ts-node crashes
+      # against it, so the client suite cannot load, and @types/mocha stops
+      # resolving from the root node_modules into the sub-projects. Both are
+      # tracked in #75, along with the tsx migration that would unblock the
+      # first. Drop this ignore when that issue closes.
+      #
+      # Majors only — 5.x updates should keep flowing.
+      - dependency-name: 'typescript'
+        update-types:
+          - 'version-update:semver-major'
     # Groups are matched in the order they are declared — a dependency joins the
     # FIRST group whose patterns match — so any specific group must precede the
     # catch-all.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/cross-spawn": "^6.0.6",
         "@types/micromatch": "^4.0.9",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^20.17.10",
+        "@types/node": "^22.20.1",
         "@types/semver": "^7.8.0",
         "@vscode/vsce": "^3.9.2",
         "esbuild": "^0.28.1",
@@ -1316,9 +1316,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.26.tgz",
-      "integrity": "sha512-0l6cjgF0XnihUpndDhk+nyD3exio3iKaYROSgvh/qSevPXax3L8p5DBRFjbvalnwatGgHEQn2R88y2fA3g4irg==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@types/cross-spawn": "^6.0.6",
     "@types/micromatch": "^4.0.9",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^20.17.10",
+    "@types/node": "^22.20.1",
     "@types/semver": "^7.8.0",
     "@vscode/vsce": "^3.9.2",
     "esbuild": "^0.28.1",

--- a/phpcs-server/package.json
+++ b/phpcs-server/package.json
@@ -16,7 +16,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "homepage": "https://github.com/JohnRDOrazio/vscode-phpcs/blob/master/README.md",
   "repository": {

--- a/phpcs/package.json
+++ b/phpcs/package.json
@@ -36,7 +36,7 @@
 		"Linters"
 	],
 	"engines": {
-		"node": ">=20",
+		"node": ">=22",
 		"vscode": "^1.106.3"
 	},
 	"activationEvents": [


### PR DESCRIPTION
Follow-up to #73. Supersedes #64.

## Why 22 is the floor

Set by the extension host, not Node's support calendar — the language server executes inside VS Code:

| | |
|---|---|
| `engines.vscode` floor | `^1.106.3` |
| VS Code 1.106.3 `.npmrc` | Electron **37.7.0** |
| Electron 37.7.0 | Node **22.20.0** |
| VS Code 1.106.3 `remote/.npmrc` | Node **22.20.0** |

## What changes

**`engines.node` `>=20` → `>=22`** in `phpcs/` and `phpcs-server/`, so the runtime manifests state the real floor instead of a stale lower bound. The root package stays at `>=22.22.1` — a separate, higher constraint that comes from `lint-staged`, not from the runtime.

**`@types/node` `^20` → `^22`** — resolves to 22.20.1, near enough the host's 22.20.0 to be the honest choice.

## Why not 26 (#64)

`@types/node` has to track the **minimum** of the supported range, not the newest entry in the matrix. Type against 26 and code compiles happily against APIs that are absent on the oldest runtime we claim to support — and unlike `@types/vscode`, there is no `vsce`-style check that would catch it.

Widening the matrix upward in #73 is not an argument for widening the types. The matrix is the range we support; the types match its floor. So:

- **20** — stale, no supported host runs it
- **26** — ahead of the runtime, unsafe
- **22** — the floor ✅

## Ignore rules — majors only

Both keep receiving patch and minor updates:

**`@types/node`** — until the floor itself moves, which means raising `engines.vscode` first.

**`typescript`** — until #75 clears TypeScript 7. It cannot be adopted today: ts-node crashes against the native port (`Cannot read properties of undefined (reading 'fileExists')`), so the client suite cannot load, and `@types/mocha` stops resolving from the root `node_modules` into the sub-projects, giving 363 errors. #75 records both, plus the `tsx` migration that would unblock the first and is worth doing on its own merits.

## Verification

On Node 22.23.2: typecheck clean under `@types/node` 22 — no new errors from the types bump — plus bundle, 221 server unit tests and the client suite.

## Merge order

Independent of #73 — no overlapping files (#73 touches the workflows and AGENTS.md; this touches manifests and `dependabot.yml`). Either order works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)