### PR TITLE
fix(client): make the phpcs path resolvers null-safe, with tests

### DIFF
--- a/phpcs/src/resolvers/composer-path-resolver.ts
+++ b/phpcs/src/resolvers/composer-path-resolver.ts
@@ -23,7 +23,10 @@ export class ComposerPhpcsPathResolver extends PhpcsPathResolverBase {
 	 * @param workspaceRoot The workspace path.
 	 * @param composerJsonPath The path to composer.json.
 	 */
-	constructor(workspaceRoot: string, workingPath?: string) {
+	// Defaulted rather than optional-and-unchecked: the sole caller always
+	// passes a value, but omitting it used to throw from path.isAbsolute
+	// instead of falling back to the workspace root's own composer.json.
+	constructor(workspaceRoot: string, workingPath: string = 'composer.json') {
 		super();
 		this._workspaceRoot = workspaceRoot;
 		this._workingPath = path.isAbsolute(workingPath)
@@ -133,8 +136,8 @@ export class ComposerPhpcsPathResolver extends PhpcsPathResolverBase {
 		return vendorPath;
 	}
 
-	async resolve(): Promise<string> {
-		let resolvedPath = null;
+	async resolve(): Promise<string | null> {
+		let resolvedPath: string | null = null;
 		if (this.workspaceRoot) {
 			// Determine whether composer.json and composer.lock exist and phpcs is defined as a dependency.
 			if (this.hasComposerJson() && this.hasComposerLock() && this.hasComposerDependency()) {

--- a/phpcs/src/resolvers/global-path-resolver.ts
+++ b/phpcs/src/resolvers/global-path-resolver.ts
@@ -10,10 +10,14 @@ import * as fs from 'fs';
 import { PhpcsPathResolverBase } from './path-resolver-base';
 
 export class GlobalPhpcsPathResolver extends PhpcsPathResolverBase {
-	async resolve(): Promise<string> {
-		let resolvedPath = null;
+	async resolve(): Promise<string | null> {
+		let resolvedPath: string | null = null;
 		let pathSeparator = /^win/.test(process.platform) ? ";" : ":";
-		let globalPaths: string[] = process.env.PATH.split(pathSeparator);
+		// PATH is not guaranteed to be set, and splitting undefined threw before
+		// the caller could report that phpcs simply was not found. Empty entries
+		// are dropped too: joining one produces a relative path, which would
+		// resolve against the current working directory by accident.
+		let globalPaths: string[] = (process.env.PATH ?? "").split(pathSeparator).filter(entry => entry.length > 0);
 		globalPaths.some((globalPath: string) => {
 			let testPath = path.join(globalPath, this.phpcsExecutableFile);
 			if (fs.existsSync(testPath)) {

--- a/phpcs/src/resolvers/path-resolver-base.ts
+++ b/phpcs/src/resolvers/path-resolver-base.ts
@@ -12,5 +12,9 @@ export abstract class PhpcsPathResolverBase {
 		this.phpcsExecutableFile = `phpcs${extension}`;
 	}
 
-	abstract resolve(): Promise<string>;
+	// Nullable because "not found here" is a normal outcome for an individual
+	// resolver — PhpcsPathResolver tries each in turn and only raises when they
+	// have all come up empty. Declaring `string` made every implementation
+	// silently return null through a type that promised otherwise.
+	abstract resolve(): Promise<string | null>;
 }

--- a/phpcs/src/resolvers/path-resolver.ts
+++ b/phpcs/src/resolvers/path-resolver.ts
@@ -26,7 +26,9 @@ export class PhpcsPathResolver extends PhpcsPathResolverBase {
 	}
 
 	async resolve(): Promise<string> {
-		let resolvedPath: string = null;
+		// Stays Promise<string> publicly: this is the resolver that turns "none
+		// of them found it" into a raised error, so callers never see null.
+		let resolvedPath: string | null = null;
 		for (let i = 0, len = this.resolvers.length; i < len; i++) {
 			let resolverPath = await this.resolvers[i].resolve();
 			if (resolvedPath !== resolverPath) {

--- a/phpcs/test/resolvers.test.ts
+++ b/phpcs/test/resolvers.test.ts
@@ -1,0 +1,241 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Ioannis Kappas. All rights reserved.
+ * Licensed under the MIT License. See License.md in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+"use strict";
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { GlobalPhpcsPathResolver } from '../src/resolvers/global-path-resolver';
+import { ComposerPhpcsPathResolver } from '../src/resolvers/composer-path-resolver';
+import { PhpcsPathResolver } from '../src/resolvers/path-resolver';
+
+// The resolvers derive the binary name from the platform, so the fixtures have
+// to agree with them or every assertion here passes on Linux and fails on the
+// Windows leg of the build matrix.
+const PHPCS_BINARY = /^win/.test(process.platform) ? 'phpcs.bat' : 'phpcs';
+
+function makeTempDir(): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), 'phpcs-resolver-'));
+}
+
+function writeFile(filePath: string, contents: string): string {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, contents);
+	return filePath;
+}
+
+suite('GlobalPhpcsPathResolver', () => {
+	let tmpDir: string;
+	let originalPath: string | undefined;
+
+	setup(() => {
+		tmpDir = makeTempDir();
+		originalPath = process.env.PATH;
+	});
+
+	teardown(() => {
+		// Assigning undefined would set the string "undefined" on some Node
+		// versions; delete then restore instead.
+		if (originalPath === undefined) {
+			delete process.env.PATH;
+		} else {
+			process.env.PATH = originalPath;
+		}
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test('resolves the executable from a directory on PATH', async () => {
+		const expected = writeFile(path.join(tmpDir, PHPCS_BINARY), '');
+		process.env.PATH = tmpDir;
+
+		const resolved = await new GlobalPhpcsPathResolver().resolve();
+
+		assert.strictEqual(resolved, expected);
+	});
+
+	test('returns null when the executable is on no PATH entry', async () => {
+		process.env.PATH = tmpDir;
+
+		const resolved = await new GlobalPhpcsPathResolver().resolve();
+
+		assert.strictEqual(resolved, null);
+	});
+
+	test('scans every PATH entry, not just the first', async () => {
+		const emptyDir = makeTempDir();
+		const expected = writeFile(path.join(tmpDir, PHPCS_BINARY), '');
+		const separator = /^win/.test(process.platform) ? ';' : ':';
+		process.env.PATH = [emptyDir, tmpDir].join(separator);
+
+		try {
+			const resolved = await new GlobalPhpcsPathResolver().resolve();
+			assert.strictEqual(resolved, expected);
+		} finally {
+			fs.rmSync(emptyDir, { recursive: true, force: true });
+		}
+	});
+
+	// PATH is not guaranteed to be set — a bare `env -i node`, a service manager
+	// with a scrubbed environment, or a test harness will all reach this. Before
+	// the strictNullChecks pass this threw "Cannot read properties of undefined
+	// (reading 'split')" instead of reporting that phpcs could not be found.
+	test('returns null rather than throwing when PATH is unset', async () => {
+		delete process.env.PATH;
+
+		const resolved = await new GlobalPhpcsPathResolver().resolve();
+
+		assert.strictEqual(resolved, null);
+	});
+});
+
+suite('ComposerPhpcsPathResolver', () => {
+	let tmpDir: string;
+
+	setup(() => {
+		tmpDir = makeTempDir();
+	});
+
+	teardown(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function scaffoldProject(options: { composerJson?: object; withBinary?: boolean; dependency?: boolean } = {}): void {
+		const { composerJson = {}, withBinary = true, dependency = true } = options;
+		writeFile(path.join(tmpDir, 'composer.json'), JSON.stringify(composerJson));
+		writeFile(
+			path.join(tmpDir, 'composer.lock'),
+			JSON.stringify({
+				'packages-dev': dependency ? [{ name: 'squizlabs/php_codesniffer' }] : [{ name: 'phpunit/phpunit' }],
+			})
+		);
+		if (withBinary) {
+			writeFile(path.join(tmpDir, 'vendor', 'bin', PHPCS_BINARY), '');
+		}
+	}
+
+	test('resolves the vendor binary when phpcs is a composer dependency', async () => {
+		scaffoldProject();
+
+		const resolved = await new ComposerPhpcsPathResolver(tmpDir, 'composer.json').resolve();
+
+		assert.strictEqual(resolved, path.join(tmpDir, 'vendor', 'bin', PHPCS_BINARY));
+	});
+
+	test('returns null when the project declares no phpcs dependency', async () => {
+		scaffoldProject({ dependency: false });
+
+		const resolved = await new ComposerPhpcsPathResolver(tmpDir, 'composer.json').resolve();
+
+		assert.strictEqual(resolved, null);
+	});
+
+	test('returns null when there is no composer project at all', async () => {
+		const resolved = await new ComposerPhpcsPathResolver(tmpDir, 'composer.json').resolve();
+
+		assert.strictEqual(resolved, null);
+	});
+
+	test('throws a directive error when the dependency is declared but not installed', async () => {
+		scaffoldProject({ withBinary: false });
+
+		await assert.rejects(
+			() => new ComposerPhpcsPathResolver(tmpDir, 'composer.json').resolve(),
+			/composer install/
+		);
+	});
+
+	test('honours a custom config.vendor-dir', async () => {
+		scaffoldProject({ composerJson: { config: { 'vendor-dir': 'custom-vendor' } }, withBinary: false });
+		const expected = writeFile(path.join(tmpDir, 'custom-vendor', 'bin', PHPCS_BINARY), '');
+
+		const resolved = await new ComposerPhpcsPathResolver(tmpDir, 'composer.json').resolve();
+
+		assert.strictEqual(resolved, expected);
+	});
+
+	test('honours a custom config.bin-dir', async () => {
+		scaffoldProject({ composerJson: { config: { 'bin-dir': 'custom-bin' } }, withBinary: false });
+		const expected = writeFile(path.join(tmpDir, 'custom-bin', PHPCS_BINARY), '');
+
+		const resolved = await new ComposerPhpcsPathResolver(tmpDir, 'composer.json').resolve();
+
+		assert.strictEqual(resolved, expected);
+	});
+
+	// The second constructor argument is declared optional. Before the
+	// strictNullChecks pass, omitting it threw from path.isAbsolute(undefined)
+	// rather than falling back to the workspace root's own composer.json.
+	test('defaults to the workspace root composer.json when no working path is given', async () => {
+		scaffoldProject();
+
+		const resolved = await new ComposerPhpcsPathResolver(tmpDir).resolve();
+
+		assert.strictEqual(resolved, path.join(tmpDir, 'vendor', 'bin', PHPCS_BINARY));
+	});
+
+	test('accepts an absolute working path', async () => {
+		scaffoldProject();
+
+		const resolver = new ComposerPhpcsPathResolver(tmpDir, tmpDir);
+
+		assert.strictEqual(resolver.workingPath, tmpDir);
+	});
+});
+
+suite('PhpcsPathResolver', () => {
+	let tmpDir: string;
+	let originalPath: string | undefined;
+
+	setup(() => {
+		tmpDir = makeTempDir();
+		originalPath = process.env.PATH;
+	});
+
+	teardown(() => {
+		if (originalPath === undefined) {
+			delete process.env.PATH;
+		} else {
+			process.env.PATH = originalPath;
+		}
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test('prefers the composer binary over one on PATH', async () => {
+		writeFile(path.join(tmpDir, 'composer.json'), '{}');
+		writeFile(path.join(tmpDir, 'composer.lock'), JSON.stringify({ packages: [{ name: 'squizlabs/php_codesniffer' }] }));
+		const vendorBinary = writeFile(path.join(tmpDir, 'vendor', 'bin', PHPCS_BINARY), '');
+
+		const globalDir = makeTempDir();
+		writeFile(path.join(globalDir, PHPCS_BINARY), '');
+		process.env.PATH = globalDir;
+
+		try {
+			const resolved = await new PhpcsPathResolver({ workspaceRoot: tmpDir, composerJsonPath: 'composer.json' }).resolve();
+			assert.strictEqual(resolved, vendorBinary);
+		} finally {
+			fs.rmSync(globalDir, { recursive: true, force: true });
+		}
+	});
+
+	test('falls back to PATH when there is no composer project', async () => {
+		const expected = writeFile(path.join(tmpDir, PHPCS_BINARY), '');
+		process.env.PATH = tmpDir;
+
+		const resolved = await new PhpcsPathResolver({ workspaceRoot: null, composerJsonPath: 'composer.json' }).resolve();
+
+		assert.strictEqual(resolved, expected);
+	});
+
+	test('throws a directive error when phpcs cannot be found anywhere', async () => {
+		process.env.PATH = tmpDir;
+
+		await assert.rejects(
+			() => new PhpcsPathResolver({ workspaceRoot: null, composerJsonPath: 'composer.json' }).resolve(),
+			/Unable to locate phpcs/
+		);
+	});
+});

--- a/phpcs/test/resolvers.test.ts
+++ b/phpcs/test/resolvers.test.ts
@@ -18,8 +18,13 @@ import { PhpcsPathResolver } from '../src/resolvers/path-resolver';
 // Windows leg of the build matrix.
 const PHPCS_BINARY = /^win/.test(process.platform) ? 'phpcs.bat' : 'phpcs';
 
+// Canonicalised deliberately. On macOS os.tmpdir() is /var/folders/…, a symlink
+// to /private/var/folders/…, and ComposerPhpcsPathResolver runs the composer.json
+// path through fs.realpathSync — so the resolver returns the real path while an
+// uncanonicalised fixture would expect the symlinked one. Linux and Windows never
+// show the difference, so this fails only on the macOS leg of the matrix.
 function makeTempDir(): string {
-	return fs.mkdtempSync(path.join(os.tmpdir(), 'phpcs-resolver-'));
+	return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'phpcs-resolver-')));
 }
 
 function writeFile(filePath: string, contents: string): string {


### PR DESCRIPTION
First slice of #78. Covers the 7 `strictNullChecks` findings in `phpcs/src/resolvers/*`, taking the client from **35 → 28**.

## Why the resolvers first

They import nothing from `vscode`, so they unit test with tsx and mocha exactly as `phpcs-server` does — no extension host needed. That makes them the one part of the 41 where the fix can be *proved* rather than reasoned about.

`phpcs/test/` gains its first real coverage: **15 tests across all three resolvers**, written before the fix. 13 passed, 2 failed — and the 2 failures were the real bugs.

## The two real bugs

**1. `PATH` is not guaranteed to be set.** `GlobalPhpcsPathResolver` called `process.env.PATH.split()` unguarded:

```
TypeError: Cannot read properties of undefined (reading 'split')
    at GlobalPhpcsPathResolver.resolve (src/resolvers/global-path-resolver.ts:16:48)
```

A scrubbed environment — `env -i`, a service manager, a test harness — got that instead of the actionable *"Unable to locate phpcs…"* the caller raises. Empty `PATH` entries are now dropped too: joining one yields a **relative** path, which `fs.existsSync` resolves against the current working directory, so a stray `./phpcs` could be picked up by accident.

**2. The optional second constructor argument was never optional.** `new ComposerPhpcsPathResolver(workspaceRoot)` threw from `path.isAbsolute(undefined)`. It now defaults to `'composer.json'` — what the only caller passes, and what the trailing `.replace(/composer.json$/, '')` already assumed.

## The rest is types catching up with behaviour

`resolve()` on the base class becomes `Promise<string | null>`, because "not found here" is the *normal* outcome for an individual resolver — `PhpcsPathResolver` tries each in turn and only raises once they have all come up empty. Declaring `string` meant every implementation returned `null` through a type promising otherwise.

`PhpcsPathResolver.resolve()` deliberately stays `Promise<string>`: it is the one that converts "none found" into a raised error, so callers still never see `null`.

## Verification

Node 22.23.2, TypeScript 7.0.2: 16 client tests, 233 server tests, typecheck, `compile`, `bundle`, `vsce package`. The resolvers are `strictNullChecks`-clean; `phpcs-server` is untouched.

Tests are platform-aware — the binary name is `phpcs.bat` on Windows, so the fixtures derive it the same way the resolvers do, rather than passing on Linux and failing on the Windows leg of the matrix.

## Next in #78

The remaining 28 are all in `phpcs/src/configuration.ts`, which *does* import `vscode` — so it cannot be covered this way and needs either extension-host tests or careful review. That is the larger and genuinely harder half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)