### PR TITLE
fix(client): make configuration.ts null-safe, mechanically

### DIFF
--- a/phpcs/src/configuration.ts
+++ b/phpcs/src/configuration.ts
@@ -61,15 +61,19 @@ export class PhpcsConfiguration extends Disposable {
 			}
 
 			let config: WorkspaceConfiguration;
-			let folder: WorkspaceFolder;
+			// Only assigned when the request carries a scope, and getWorkspaceFolder
+			// returns undefined for a resource outside every folder. The `if (folder)`
+			// checks below already assumed this; the declaration did not.
+			let folder: WorkspaceFolder | undefined;
 			if (item.scopeUri) {
 				let resource = this.client.protocol2CodeConverter.asUri(item.scopeUri);
 				folder = workspace.getWorkspaceFolder(resource);
 			}
 
 			if (folder) {
-				if (this.folderSettings.has(folder.uri)) {
-					result.push(this.folderSettings.get(folder.uri));
+				const cached = this.folderSettings.get(folder.uri);
+				if (cached) {
+					result.push(cached);
 					continue;
 				}
 				config = workspace.getConfiguration('phpcs', folder.uri);
@@ -81,28 +85,38 @@ export class PhpcsConfiguration extends Disposable {
 				config = workspace.getConfiguration('phpcs');
 			}
 
+			// Every default below is the one declared for the same key in
+			// package.json under contributes.configuration. The single-argument
+			// config.get() returns `T | undefined`, which is honest — it yields
+			// undefined for a key VS Code does not know about — so the fields it
+			// filled were only non-undefined by the grace of the manifest. Passing
+			// the default explicitly makes that dependency visible and gives the
+			// two-argument overload, which returns `T`.
+			//
+			// These must stay in step with the manifest; a value drifting here
+			// would change behaviour silently for anyone who has not set the key.
 			let settings: PhpcsSettings = {
-				enable: config.get('enable'),
+				enable: config.get<boolean>('enable', true),
 				workspaceRoot: folder ? folder.uri.fsPath : null,
-				executablePath: config.get('executablePath'),
-				composerJsonPath: config.get('composerJsonPath'),
-				standard: config.get('standard'),
-				autoConfigSearch: config.get('autoConfigSearch'),
-				showSources: config.get('showSources'),
-				showWarnings: config.get('showWarnings'),
-				ignorePatterns: config.get('ignorePatterns'),
-				ignoreSource: config.get('ignoreSource'),
-				warningSeverity: config.get('warningSeverity'),
-				errorSeverity: config.get('errorSeverity'),
-				lintOnType: config.get('lintOnType'),
-				lintOnOpen: config.get('lintOnOpen'),
-				lintOnSave: config.get('lintOnSave'),
-				queueBuffer: config.get('queueBuffer'),
-				lintOnlyOpened: config.get('lintOnlyOpened'),
+				executablePath: config.get<string | null>('executablePath', null),
+				composerJsonPath: config.get<string>('composerJsonPath', 'composer.json'),
+				standard: config.get<string | null>('standard', null),
+				autoConfigSearch: config.get<boolean>('autoConfigSearch', true),
+				showSources: config.get<boolean>('showSources', false),
+				showWarnings: config.get<boolean>('showWarnings', true),
+				ignorePatterns: config.get<string[]>('ignorePatterns', []),
+				ignoreSource: config.get<string[]>('ignoreSource', []),
+				warningSeverity: config.get<number>('warningSeverity', 5),
+				errorSeverity: config.get<number>('errorSeverity', 5),
+				lintOnType: config.get<boolean>('lintOnType', true),
+				lintOnOpen: config.get<boolean>('lintOnOpen', true),
+				lintOnSave: config.get<boolean>('lintOnSave', true),
+				queueBuffer: config.get<number>('queueBuffer', 10),
+				lintOnlyOpened: config.get<boolean>('lintOnlyOpened', true),
 				// PHPCBF settings
-				phpcbfEnable: config.get('phpcbfEnable'),
-				phpcbfExecutablePath: config.get('phpcbfExecutablePath'),
-				phpcbfOnSave: config.get('phpcbfOnSave'),
+				phpcbfEnable: config.get<boolean>('phpcbfEnable', true),
+				phpcbfExecutablePath: config.get<string | null>('phpcbfExecutablePath', null),
+				phpcbfOnSave: config.get<boolean>('phpcbfOnSave', false),
 			};
 
 			settings = await this.resolveExecutablePath(settings);

--- a/phpcs/src/settings.ts
+++ b/phpcs/src/settings.ts
@@ -8,7 +8,11 @@ export interface PhpcsSettings {
 	enable: boolean;
 	workspaceRoot: string | null;
 	executablePath: string | null;
-	composerJsonPath: string | null;
+	// Not nullable: package.json declares this `type: "string"` with a default
+	// of "composer.json", so it is always a string by the time it is read. The
+	// wider type let a null reach path.isAbsolute() in the composer resolver,
+	// which throws rather than reporting that phpcs could not be found.
+	composerJsonPath: string;
 	standard: string | null;
 	autoConfigSearch: boolean;
 	showSources: boolean;


### PR DESCRIPTION
Second slice of #78 — groups **A, B, D and E** from the [breakdown recorded there](https://github.com/JohnRDOrazio/vscode-phpcs/issues/78#issuecomment-5299996073). 25 findings, all type-level, **no behaviour change**.

Group C (3 findings) is deliberately left: those need a stated decision, not a mechanical fix.

## A — 20 findings: `config.get()` returns `T | undefined`

The fields it filled were non-undefined only *by the grace of* `package.json` declaring a default for every key. Each call now passes that default explicitly, which selects the two-argument overload returning `T`:

```diff
-enable: config.get('enable'),
+enable: config.get<boolean>('enable', true),
```

**All 19 defaults were cross-checked against `contributes.configuration` programmatically**, not transcribed by hand — a value drifting from the manifest here would change behaviour silently for anyone who has not set that key, which is the one way this could have gone wrong.

## B — 4 findings: `folder` declared as always-present

`let folder: WorkspaceFolder` was assigned only inside `if (item.scopeUri)`, and `workspace.getWorkspaceFolder()` returns `undefined` for a resource outside every folder. The `if (folder)` guards already assumed that; only the declaration disagreed.

## D — 1 finding: `has()` then `get()`

Two lookups producing `T | undefined` for no reason. One lookup instead.

## E — 1 finding: a type wider than reality

`PhpcsSettings.composerJsonPath` was `string | null`, while `PhpcsPathResolverOptions` requires `string`. The manifest declares it `type: "string"` with a default of `"composer.json"`, so null was never reachable — and had it been, it would have reached `path.isAbsolute(null)` and thrown `TypeError: The "path" argument must be of type string` rather than reporting that phpcs could not be found. Narrowed to match reality.

## 🐛 A real bug found along the way — not fixed here

The cross-check compared manifest keys against keys the client reads, and turned up **`phpcs.phpcbfTimeout`: declared, documented, and never sent to the server.** The server reads it with `?? DEFAULT_PHPCBF_TIMEOUT_SECONDS`, so it silently falls back and the user's value is discarded — while the timeout message tells them to increase exactly that setting.

Filed as #81. Kept out of this PR on purpose: it changes behaviour, since anyone who has already set `phpcbfTimeout` would see it take effect for the first time. That belongs in its own commit rather than folded into a null-safety pass.

## Verification

Node 22.23.2 under TypeScript 7.0.2: typecheck, `bundle`, `npm test`, `vsce package`.

`strictNullChecks` findings in `phpcs/` drop **28 → 3**. (This branch still shows 10, because the other 7 are the resolvers, fixed separately in #80.)

## After this

- #80 — resolvers (open, green)
- Group C — three decisions
- then `strictNullChecks: true`, then `strictPropertyInitialization` for the last 6 in `status.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration handling for PHPCS and PHPCBF settings.
  * Added reliable default values for configuration options.
  * Improved workspace-specific settings behavior when cached values are unavailable.
  * Prevented invalid empty package configuration paths from affecting path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->