### PR TITLE
fix(client): send phpcbfTimeout to the server

### DIFF
--- a/phpcs/src/configuration.ts
+++ b/phpcs/src/configuration.ts
@@ -117,6 +117,7 @@ export class PhpcsConfiguration extends Disposable {
 				phpcbfEnable: config.get<boolean>('phpcbfEnable', true),
 				phpcbfExecutablePath: config.get<string | null>('phpcbfExecutablePath', null),
 				phpcbfOnSave: config.get<boolean>('phpcbfOnSave', false),
+				phpcbfTimeout: config.get<number>('phpcbfTimeout', 60),
 			};
 
 			settings = await this.resolveExecutablePath(settings);

--- a/phpcs/src/settings.ts
+++ b/phpcs/src/settings.ts
@@ -30,4 +30,5 @@ export interface PhpcsSettings {
 	phpcbfEnable: boolean;
 	phpcbfExecutablePath: string | null;
 	phpcbfOnSave: boolean;
+	phpcbfTimeout: number;
 }


### PR DESCRIPTION
Closes #81.

`phpcs.phpcbfTimeout` is declared in `package.json` with a 1–300 second range and the description *"Increase for large files"*, the server declares it in its own `PhpcsSettings`, and `fixer.ts` reads it — but **the client never put it in the settings object it sends**.

It arrived `undefined`, `settings.phpcbfTimeout ?? DEFAULT_PHPCBF_TIMEOUT_SECONDS` fell back to 60, and the user's value was discarded. The `??` is exactly what made it silent; without it there would have been a visible failure years ago.

The timeout message compounded it:

```
PHPCBF operation timed out after {0} seconds.
Try increasing phpcs.phpcbfTimeout for large files.
```

Users following that instruction saw no change.

## The fix

Two lines — the field on the client's `PhpcsSettings`, and:

```ts
phpcbfTimeout: config.get<number>('phpcbfTimeout', 60),
```

60 matches both the manifest default and `server.ts:85`.

## Verification that this was the only one

The cross-check that found it (added in #82) now reports:

- **20 keys read**, zero default mismatches against the manifest
- the only unread `phpcs.*` key is `trace.server`, which the language client library handles itself
- **client and server `PhpcsSettings` have identical field sets** — no drift in either direction

That last check answers the open question I left on #81: nothing else is being dropped on the way to the server, and nothing the server expects is missing.

## Behaviour change

Deliberate, and the reason this was kept out of #82: anyone who has already set `phpcbfTimeout` will see it take effect for the first time. That is what the setting has always claimed to do.

Node 22.23.2, TypeScript 7.0.2: typecheck, `bundle`, 16 client + 233 server tests, `vsce package`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)