### PR TITLE
fix(client): resolve the last null-safety cases and enable strictNullChecks

### DIFF
--- a/phpcs/src/configuration.ts
+++ b/phpcs/src/configuration.ts
@@ -27,9 +27,13 @@ import { PhpcsPathResolver } from "./resolvers/path-resolver";
 
 export class PhpcsConfiguration extends Disposable {
 
-	private client: LanguageClient;
+	// Nulled on dispose to release the reference, so the field is nullable and
+	// reached through the accessor below rather than directly.
+	private client: LanguageClient | null;
 	private disposables: Array<Disposable> = [];
-	private globalSettings: PhpcsSettings;
+	// Null rather than undefined-until-first-computed. The `if (this.globalSettings)`
+	// check below already treated it as absent-or-present; the type now says so.
+	private globalSettings: PhpcsSettings | null = null;
 	private folderSettings: Map<Uri, PhpcsSettings> = new Map();
 
 	/**
@@ -45,11 +49,32 @@ export class PhpcsConfiguration extends Disposable {
 		this.client = client;
 	}
 
+	/**
+	 * The language client, or a clear failure if this object has been disposed.
+	 *
+	 * Every use here is reached from a callback registered while the object was
+	 * live, so a null client means something is running after dispose. That was
+	 * already fatal — it threw "Cannot read properties of null" from whichever
+	 * property happened to be touched first. This says which object is at fault.
+	 */
+	private get languageClient(): LanguageClient {
+		if (this.client === null) {
+			throw new Error('PhpcsConfiguration has been disposed and can no longer be used.');
+		}
+		return this.client;
+	}
+
 	// Convert VS Code specific settings to a format acceptable by the server. Since
 	// both client and server do use JSON the conversion is trivial.
 	public async compute(params: ConfigurationParams, _token: CancellationToken, _next: Function): Promise<any[]> {
+		// An empty result rather than null. The declared Promise<any[]> is not
+		// negotiable — vscode-languageclient's MiddlewareSignature requires an
+		// array, so returning null was a protocol violation as well as a type
+		// error. `items` is required by the LSP spec, so this is defensive
+		// anyway, and an empty array is the correct answer to a request that
+		// asks for nothing.
 		if (!params.items) {
-			return null;
+			return [];
 		}
 		let result: (PhpcsSettings | null)[] = [];
 		for (let item of params.items) {
@@ -66,7 +91,7 @@ export class PhpcsConfiguration extends Disposable {
 			// checks below already assumed this; the declaration did not.
 			let folder: WorkspaceFolder | undefined;
 			if (item.scopeUri) {
-				let resource = this.client.protocol2CodeConverter.asUri(item.scopeUri);
+				let resource = this.languageClient.protocol2CodeConverter.asUri(item.scopeUri);
 				folder = workspace.getWorkspaceFolder(resource);
 			}
 
@@ -143,7 +168,7 @@ export class PhpcsConfiguration extends Disposable {
 					? path.basename(settings.workspaceRoot)
 					: 'global';
 				const message = error instanceof Error ? error.message : String(error);
-				this.client.outputChannel.appendLine(`[Warning] ${folderName}: ${message}`);
+				this.languageClient.outputChannel.appendLine(`[Warning] ${folderName}: ${message}`);
 				// Leave executablePath as null - the server will skip validation for this folder
 			}
 		} else if (!path.isAbsolute(settings.executablePath) && settings.workspaceRoot !== null) {
@@ -158,7 +183,7 @@ export class PhpcsConfiguration extends Disposable {
 		this.disposables.push(workspace.onDidChangeConfiguration(() => {
 			this.folderSettings.clear();
 			this.globalSettings = null;
-			this.client.sendNotification(DidChangeConfigurationNotification.type, { settings: null });
+			this.languageClient.sendNotification(DidChangeConfigurationNotification.type, { settings: null });
 		}));
 	}
 }

--- a/phpcs/tsconfig.json
+++ b/phpcs/tsconfig.json
@@ -1,12 +1,11 @@
 {
 	"compilerOptions": {
-		// Explicit rather than inherited: TypeScript 5 defaults strict to false
-		// and TypeScript 7 defaults it to true, so a bare compiler upgrade would
-		// silently turn it on here. The client has 41 strict findings — the same
-		// 41 under 5.9.3 and 7.0.2, so pre-existing debt rather than anything the
-		// upgrade introduced. Tracked in #78; sibling phpcs-server already sets
-		// this to true.
+		// Not yet the umbrella "strict": true that phpcs-server carries — that
+		// also turns on strictPropertyInitialization, which still reports the
+		// uninitialised status bar fields in status.ts. strictNullChecks is on
+		// and clean; the rest of #78 is what closes the gap.
 		"strict": false,
+		"strictNullChecks": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noImplicitAny": true,


### PR DESCRIPTION
Third and last slice of #78's `strictNullChecks` work — group C, the three that needed a decision rather than a mechanical edit. `phpcs/` is now clean under the flag, so **the flag is on**.

## The disposed client

`this.client = null` in the dispose callback, against a field typed `LanguageClient`. The field is now nullable and its three uses go through a private accessor:

```ts
private get languageClient(): LanguageClient {
    if (this.client === null) {
        throw new Error('PhpcsConfiguration has been disposed and can no longer be used.');
    }
    return this.client;
}
```

Use-after-dispose was **already fatal** — it threw `Cannot read properties of null` from whichever property happened to be touched first. This preserves the failure and only improves what it says.

## `compute()` returning null

I tried the behaviour-preserving option first — widening to `Promise<any[] | null>` — and it does not compile:

```
extension.ts(60,4): error TS2322: Type '… => Promise<any[] | null>'
is not assignable to type 'MiddlewareSignature'.
```

`vscode-languageclient`'s `MiddlewareSignature` requires `any[]`. So `return null` was **a protocol violation as much as a type error** — it would have handed `null` to a `workspace/configuration` response that must be an array.

It returns `[]` instead. `items` is required by the LSP spec, so the branch is defensive anyway, and an empty array is the correct answer to a request that asks for nothing.

## `globalSettings`

Nulled on configuration change against a non-nullable field, and `undefined` until first computed. Now `PhpcsSettings | null` initialised to `null` — which is exactly what the `if (this.globalSettings)` check always assumed.

## The flag

`phpcs/tsconfig.json` gains `"strictNullChecks": true`.

Deliberately **not** the umbrella `"strict": true` that `phpcs-server` carries: that also enables `strictPropertyInitialization`, which still reports five uninitialised fields —

| File | Fields |
|---|---|
| `status.ts` | `statusBarItem`, `timer`, `standardStatusBarItem` |
| `resolvers/composer-path-resolver.ts` | `_composerJsonPath`, `_composerLockPath` (lazy caches) |

That is the remaining step in #78, and the last thing between the two projects having identical strictness.

## Verification

Node 22.23.2, TypeScript 7.0.2: typecheck with the new flag, `compile`, `bundle`, 16 client + 233 server tests, `vsce package`.

## Journey so far on #78

| Slice | Findings | |
|---|---|---|
| #80 | 7 | resolvers, with the first real client tests |
| #82 | 25 | `configuration.ts`, mechanical |
| this | 3 | group C, plus the flag |
| remaining | 5 | `strictPropertyInitialization` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)