### PR TITLE
fix(client): type the lazily-initialised fields, enable full strict

### DIFF
--- a/phpcs/src/resolvers/composer-path-resolver.ts
+++ b/phpcs/src/resolvers/composer-path-resolver.ts
@@ -14,8 +14,12 @@ export class ComposerPhpcsPathResolver extends PhpcsPathResolverBase {
 	protected readonly _workspaceRoot: string;
 	protected readonly _workingPath: string;
 
-	protected _composerJsonPath: string;
-	protected _composerLockPath: string;
+	// Lazy caches, resolved on first access by the getters below. Left
+	// unresolved in the constructor because fs.realpathSync throws when the
+	// file is absent, which is a normal case here — hasComposerJson() exists
+	// precisely to ask.
+	protected _composerJsonPath: string | undefined;
+	protected _composerLockPath: string | undefined;
 
 	/**
 	 * Class constructor.

--- a/phpcs/src/status.ts
+++ b/phpcs/src/status.ts
@@ -17,15 +17,19 @@ import { Timer } from './timer';
 
 export class PhpcsStatus {
 
-	private statusBarItem: StatusBarItem;
+	// Created on first use by getStatusBarItem(), not in the constructor — a
+	// status bar item is only worth allocating once there is something to show.
+	private statusBarItem: StatusBarItem | undefined;
 	private documents: string[] = [];
 	private processing: number = 0;
 	private buffered: number = 0;
 	private spinnerIndex = 0;
 	private spinnerSequence: string[] = ["|", "/", "-", "\\"];
-	private timer: Timer;
+	// Likewise created on demand by getTimer().
+	private timer: Timer | undefined;
 	private channel: OutputChannel;
-	private standardStatusBarItem: StatusBarItem;
+	// Likewise created on demand by getStandardStatusBarItem().
+	private standardStatusBarItem: StatusBarItem | undefined;
 	private documentStandards: Map<string, string | null> = new Map();
 
 	public constructor()

--- a/phpcs/tsconfig.json
+++ b/phpcs/tsconfig.json
@@ -1,11 +1,10 @@
 {
 	"compilerOptions": {
-		// Not yet the umbrella "strict": true that phpcs-server carries — that
-		// also turns on strictPropertyInitialization, which still reports the
-		// uninitialised status bar fields in status.ts. strictNullChecks is on
-		// and clean; the rest of #78 is what closes the gap.
-		"strict": false,
-		"strictNullChecks": true,
+		// Matches phpcs-server. Reached in stages through #78: the resolvers, then
+		// configuration.ts, then the lazily-initialised fields this last flag
+		// covers. Explicit rather than inherited, because TypeScript 5 defaults
+		// it to false and 7 defaults it to true.
+		"strict": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noImplicitAny": true,


### PR DESCRIPTION
Closes #78. `phpcs/tsconfig.json` now declares `"strict": true`, matching `phpcs-server` — **both projects clean under the same flag.**

## The last five were one pattern

Every remaining `strictPropertyInitialization` finding was a field created on first use behind an `if (!this.x)` accessor, declared as though the constructor had set it:

| File | Fields |
|---|---|
| `status.ts` | `statusBarItem`, `timer`, `standardStatusBarItem` |
| `resolvers/composer-path-resolver.ts` | `_composerJsonPath`, `_composerLockPath` |

Typing them `| undefined` is simply the honest description — they genuinely *are* undefined until first use — and the existing accessors already narrow, so **no call site changed**.

Worth noting the composer caches are deliberately not resolved in the constructor: `fs.realpathSync` throws when the file is absent, which is a perfectly normal case here — `hasComposerJson()` exists precisely to ask that question. Eager initialisation would have turned "no composer project" into an exception.

## How #78 was cleared

| Slice | Findings | |
|---|---|---|
| #80 | 7 | resolvers, with the first real client tests |
| #82 | 25 | `configuration.ts`, mechanical |
| #84 | 3 | the cases needing a decision, plus `strictNullChecks` |
| **this** | **5** | lazy initialisation, plus the umbrella flag |

Every count measured, not estimated — including the one measurement that corrected the others, when `typecheck`'s `&&` turned out to be hiding the client behind the server.

## What it was actually worth

The 41 were **pre-existing debt**, identical under TypeScript 5.9.3 and 7.0.2. TypeScript 7 didn't introduce them; it flipped the default for `strict` and made them visible.

Two were real crashes rather than type noise:

- `process.env.PATH.split()` unguarded — a scrubbed environment got `Cannot read properties of undefined` instead of *"Unable to locate phpcs"*
- an "optional" constructor argument that threw from `path.isAbsolute(undefined)` when omitted

And the pass turned up two more things that weren't strict-mode issues at all: the `phpcbfTimeout` setting that was never sent to the server (#81, fixed in #83), and `compute()` returning `null` where `MiddlewareSignature` requires an array — a protocol violation, not just a type error.

## Verification

Node 22.23.2, TypeScript 7.0.2: typecheck, `compile`, `bundle`, 16 client + 233 server tests, `vsce package`, markdownlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when Composer configuration or lock files are missing, preventing unnecessary startup errors.
  * Status indicators are now created only when needed, improving extension startup reliability and resource usage.
  * Preserved cached path resolution for faster repeated access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->