### PR TITLE
fix(dev): give phpcs-server its own build output, correct the F5 docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 */out/
 */dist/
 *.vsix
+# Legacy: phpcs-server emitted here before it owned its own out/. Kept so a
+# stale directory in an existing checkout cannot be committed by accident.
 phpcs/server
 
 # General

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,14 +67,21 @@ npm run format:md          # Format markdown files with Prettier
 ### Running and Debugging in VS Code
 
 The extension runs from the esbuild bundle in `phpcs/dist/`. **F5 builds it for
-you** — each launch configuration has a `preLaunchTask` that starts the matching
-esbuild watcher and waits for its first build to finish before the extension
-host starts.
+you** — both launch configurations carry a `preLaunchTask` that starts the
+matching esbuild watcher and waits for its first build to finish.
 
 Use VS Code's **Run and Debug** panel:
 
-- **Launch Extension** - Starts the extension in a new VS Code window
-- **Client+Server** - Launches extension with server debugging attached
+- **Launch Extension** - `preLaunchTask: watch:client` starts the client
+  watcher, then launches a new VS Code window with the extension loaded
+- **Attach to Server** - `preLaunchTask: watch:server` starts the server
+  watcher, then attaches to port 6199. It is `request: attach`, so it launches
+  nothing itself: the language server has to be running already, which it is
+  once the extension host has spawned it with `--inspect=6199` (see
+  `debugOptions` in `phpcs/src/extension.ts`)
+- **Client+Server** - a compound running both of the above, so client and
+  server are debuggable together. It has no `preLaunchTask` of its own; each
+  configuration brings one
 
 Building by hand first is optional:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,19 +66,30 @@ npm run format:md          # Format markdown files with Prettier
 
 ### Running and Debugging in VS Code
 
-The extension uses esbuild to bundle files to `phpcs/dist/`. Before using
-**Run and Debug** (F5), you must build the extension:
+The extension runs from the esbuild bundle in `phpcs/dist/`. **F5 builds it for
+you** — each launch configuration has a `preLaunchTask` that starts the matching
+esbuild watcher and waits for its first build to finish before the extension
+host starts.
 
-```bash
-npm run bundle-dev         # One-time build
-# OR
-npm run bundle-watch       # Continuous watch mode (recommended for development)
-```
-
-Then use VS Code's **Run and Debug** panel to launch:
+Use VS Code's **Run and Debug** panel:
 
 - **Launch Extension** - Starts the extension in a new VS Code window
 - **Client+Server** - Launches extension with server debugging attached
+
+Building by hand first is optional:
+
+```bash
+npm run bundle-dev         # One-time build
+npm run bundle-watch       # Continuous watch mode, outside a debug session
+```
+
+**A naming trap worth knowing.** The `watch:client` and `watch:server` *tasks*
+in `.vscode/tasks.json` run the `esbuild-watch:*` npm scripts — not the
+same-named `watch:*` scripts in `package.json`, which are `tsc -w` and emit
+somewhere the extension never loads from. `preLaunchTask` resolves against task
+labels, and a task label shadows an npm script of the same name. Reading
+`launch.json` against `package.json` alone therefore suggests F5 builds the
+wrong output; it does not. That misreading is what produced issue #74.
 
 ## PHPCS Version Compatibility
 

--- a/phpcs-server/package.json
+++ b/phpcs-server/package.json
@@ -47,7 +47,7 @@
     "test:unit": "node --import tsx node_modules/mocha/bin/mocha.js --ui tdd --timeout 10000 test/linter.test.ts test/linter-utils.test.ts test/fixer-utils.test.ts test/code-actions.test.ts test/lsp-protocol.test.ts test/base/common/strings.test.ts",
     "test:integration": "node --import tsx node_modules/mocha/bin/mocha.js --ui tdd --timeout 10000 test/integration.test.ts test/fixer.test.ts test/lsp-protocol.test.ts",
     "test:coverage": "c8 --reporter=lcov --reporter=text node --import tsx node_modules/mocha/bin/mocha.js --ui tdd --timeout 10000 test/**/*.test.ts",
-    "clean": "rimraf ../phpcs/server"
+    "clean": "rimraf out"
   },
   "overrides": {
     "serialize-javascript": "^7.0.7"

--- a/phpcs-server/tsconfig.json
+++ b/phpcs-server/tsconfig.json
@@ -13,7 +13,11 @@
 		"moduleResolution": "node16",
 		"sourceMap": true,
 		"lib": [ "ES2022" ],
-		"outDir": "../phpcs/server",
+		// Own package, mirroring phpcs/tsconfig.json. It used to emit into
+		// ../phpcs/server, from the era when the server shipped as loose JS inside
+		// the extension; esbuild has bundled it to phpcs/dist/server.js since, so
+		// that path was scratch space wearing a shipping name.
+		"outDir": "out",
 		"skipLibCheck": true,
 		// Ambient type packages are named explicitly rather than left to
 		// whatever happens to be in node_modules. TypeScript 5 auto-includes

--- a/phpcs/.vscodeignore
+++ b/phpcs/.vscodeignore
@@ -3,6 +3,8 @@ typings/**
 test/**
 src/**
 out/**
+# Legacy: phpcs-server emitted here before it owned its own out/. Kept so a
+# stale directory cannot be packaged into the vsix.
 server/**
 node_modules/**
 esbuild.js

--- a/phpcs/tsconfig.json
+++ b/phpcs/tsconfig.json
@@ -24,7 +24,6 @@
 		"types": ["node", "mocha", "vscode"]
 	},
 	"exclude": [
-		"node_modules",
-		"server"
+		"node_modules"
 	]
 }


### PR DESCRIPTION
Addresses #74 — but **not the part that issue claimed.**

## ❌ F5 was never broken. I filed that issue on a misreading.

#74 said `launch.json`'s `preLaunchTask` builds output the extension never loads. It does not:

```
task label 'watch:client'  →  npm script: esbuild-watch:client  →  phpcs/dist/
                                                                    ↑ where outFiles points
```

`preLaunchTask` resolves against **task labels**, and the `watch:client` / `watch:server` labels in `.vscode/tasks.json` run the `esbuild-watch:*` scripts. They *shadow* the same-named `watch:*` scripts in `package.json`, which are `tsc -w`. Reading `launch.json` against `package.json` alone produces exactly the wrong conclusion — which is how the issue came to be filed.

The dev setup was already fixed in `3428f20` (January 2026). The AGENTS.md instruction to build before pressing F5 was written in `d77475b` (**July 2026** — *after* the fix), describing work the `preLaunchTask` already does. It read as evidence of a bug that wasn't there.

AGENTS.md now says F5 builds for itself, and names the task-label-shadows-npm-script trap outright so the next reader doesn't repeat it.

## ✅ The outDir coupling was real

`phpcs-server` emitted into `../phpcs/server` — a path that reads like the server ships inside the extension. It did once; esbuild has bundled it to `phpcs/dist/server.js` since, leaving that directory as scratch space wearing a shipping name, and forcing `phpcs/tsconfig.json` to exclude it so the client project wouldn't compile the server's output.

| | before | after |
|---|---|---|
| `phpcs-server` outDir | `../phpcs/server` | `out` |
| `phpcs-server` clean | `rimraf ../phpcs/server` | `rimraf out` |
| `phpcs/tsconfig.json` exclude | `["node_modules", "server"]` | `["node_modules"]` |

`phpcs-server/out` needed no new ignore rule — `*/out/` already covered it, verified with `git check-ignore`.

## The two guards stay, annotated

`phpcs/server` remains in `.gitignore` and `.vscodeignore`. Nothing writes there any more, but **existing checkouts still have the directory** — mine did — and removing the guards would let stale JS be committed or packaged into the vsix. Both entries now say why they outlive the thing they guarded.

## Verification

Node 22.23.2: `clean` (removes the new `out`), `compile` (creates `phpcs-server/out`, no `phpcs/server`), typecheck, `bundle`, 16 client + 236 server tests, and `vsce package` — whose vsix contains `dist/extension.js` and `dist/server.js` and no `server/` directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected server build output and cleanup paths to use the local output directory.
  * Prevented stale or legacy output directories from being included in packaged extensions.

* **Documentation**
  * Clarified VS Code debugging, automatic builds, launch configurations, and optional manual bundling.
  * Documented build output and compatibility behavior for existing development setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->