### PR TITLE
fix(security): override serialize-javascript in phpcs

### DIFF
--- a/phpcs/package-lock.json
+++ b/phpcs/package-lock.json
@@ -1313,16 +1313,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
 		"node_modules/readdirp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -1347,27 +1337,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/semver": {
 			"version": "7.8.5",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -1381,13 +1350,13 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
+			"integrity": "sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
-			"dependencies": {
-				"randombytes": "^2.1.0"
+			"engines": {
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/shebang-command": {

--- a/phpcs/package.json
+++ b/phpcs/package.json
@@ -220,6 +220,9 @@
 		"test": "node --import tsx node_modules/mocha/bin/mocha.js --ui tdd --timeout 10000 test/**/*.test.ts",
 		"clean": "rimraf out"
 	},
+	"overrides": {
+		"serialize-javascript": "^7.0.7"
+	},
 	"devDependencies": {
 		"@types/vscode": "^1.106.0",
 		"mocha": "^11.8.0",


### PR DESCRIPTION
Closes Dependabot alerts [119](https://github.com/JohnRDOrazio/vscode-phpcs/security/dependabot/119) and [120](https://github.com/JohnRDOrazio/vscode-phpcs/security/dependabot/120), both against `phpcs/package-lock.json`.

| Advisory | Severity | Issue | Vulnerable |
|---|---|---|---|
| GHSA-5c6j-r48x-rmvq | **high** | RCE via `RegExp.flags` and `Date.prototype.toISOString()` | `<= 7.0.2` |
| CVE-2026-34043 | medium | CPU exhaustion DoS via crafted array-like objects | `< 7.0.5` |

`phpcs` resolved **serialize-javascript 6.0.2**, transitively through mocha, and had no override.

## Why only `phpcs` was exposed

```
package.json          overrides: serialize-javascript ^7.0.7   ← but not in its tree at all
phpcs/package.json    (none)                                   ← mocha → 6.0.2  ✗
phpcs-server/package.json  overrides: serialize-javascript ^7.0.7  ← 7.0.7  ✓
```

**This is fallout from #77.** That change moved `mocha` out of the root and into `phpcs` so each package owns its test runner — but the override guarding mocha's transitive `serialize-javascript` did not move with it. The root override became dead (the package is no longer in that tree at all), while `phpcs` inherited the dependency *without* the guard.

The uncomfortable part: the root override made the repository look protected. It wasn't — `overrides` is per-package, and relocating a dependency silently stepped outside it.

## The fix

`phpcs` now carries the same `^7.0.7` override, resolving **7.1.0**.

The dead root override **stays**. Keeping all three aligned means a dependency landing in any package is guarded, rather than protected only where someone remembered — which is exactly the failure mode above.

## Verification

- `serialize-javascript` no longer appears in `npm audit` for `phpcs`
- mocha still runs under serialize-javascript 7 — 16 client and 236 server tests pass, and `phpcs-server` has been running that combination all along
- typecheck, `bundle`, `vsce package`

Worth noting these were **dev-scope**: `serialize-javascript` reaches mocha's parallel-mode serialization, never the published extension, which ships only the esbuild bundle.

## Deliberately untouched

Two low-severity findings for `diff` via mocha (GHSA-73rr-hh4g-fpgx), which `phpcs-server` carries identically. Dev-only, and clearing them would mean overriding across a major of mocha's diff renderer — not something to fold into a security fix. Happy to do it separately if you want the audit fully clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)