### PR TITLE
chore(release): 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-phpcs",
   "description": "PHP CodeSniffer for Visual Studio Code",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": "Ioannis Kappas",
   "publisher": "johnrdorazio",
   "contributors": [

--- a/phpcs-server/package.json
+++ b/phpcs-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-phpcs-server",
   "description": "PHP Code Sniffer server.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": "Ioannis Kappas",
   "publisher": "johnrdorazio",
   "contributors": [

--- a/phpcs/CHANGELOG.md
+++ b/phpcs/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to the "vscode-phpcs" extension will be documented in this f
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-08-15
+
+### Fixed
+
+- **`phpcs.phpcbfTimeout` now takes effect**: the setting was declared,
+  documented and range-validated, but the client never sent it to the server,
+  so PHPCBF always used the 60 second default — including for anyone following
+  the timeout message's own advice to raise it
+  ([#81](https://github.com/JohnRDOrazio/vscode-phpcs/issues/81))
+- **No longer crashes when `PATH` is unset**: resolving the phpcs executable in
+  an environment with no `PATH` threw
+  `TypeError: Cannot read properties of undefined (reading 'split')` instead of
+  reporting that phpcs could not be found
+  ([#80](https://github.com/JohnRDOrazio/vscode-phpcs/pull/80))
+- **Empty `PATH` entries no longer resolve a relative executable**: a trailing
+  separator in `PATH` produced an empty entry, which joined to a bare `phpcs`
+  and was then resolved against the working directory — so a file named `phpcs`
+  in the open workspace could be selected as the linter
+  ([#80](https://github.com/JohnRDOrazio/vscode-phpcs/pull/80))
+
+### Changed
+
+- **Language Server Protocol 3.18**: `vscode-languageclient` and
+  `vscode-languageserver` upgraded from 9 to 10. No change in behaviour; the
+  bundled server grows from 292 KB to 312 KB
+  ([#71](https://github.com/JohnRDOrazio/vscode-phpcs/pull/71))
+- **`engines.node` raised to `>=22`**, matching the runtime the oldest
+  supported VS Code actually provides: 1.106.3 ships Electron 37.7.0, which is
+  Node 22.20.0. VS Code does not enforce this field, so installation is
+  unaffected ([#76](https://github.com/JohnRDOrazio/vscode-phpcs/pull/76))
+
 ## [1.3.0] - 2026-07-18
 
 ### Added

--- a/phpcs/package.json
+++ b/phpcs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "vscode-phpcs",
 	"description": "PHP CodeSniffer for Visual Studio Code",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"author": "Ioannis Kappas",
 	"publisher": "johnrdorazio",
 	"contributors": [


### PR DESCRIPTION
Patch release. Three user-facing fixes, one shipped dependency major, no new features or settings.

Of the 43 commits since 1.3.0, only 12 files that actually ship changed — the rest is tooling.

## Fixed

- **`phpcs.phpcbfTimeout` now takes effect** ([#81](https://github.com/JohnRDOrazio/vscode-phpcs/issues/81)). Declared, documented and range-validated, but never sent from client to server — so PHPCBF always used the 60 second default, including for anyone following the timeout message's own advice to raise it.
- **No longer crashes when `PATH` is unset** ([#80](https://github.com/JohnRDOrazio/vscode-phpcs/pull/80)). `TypeError: Cannot read properties of undefined (reading 'split')` instead of *"Unable to locate phpcs"*.
- **Empty `PATH` entries no longer resolve a relative executable** ([#80](https://github.com/JohnRDOrazio/vscode-phpcs/pull/80)). A trailing separator produced an empty entry, joined to a bare `phpcs` and resolved against the working directory — so a file named `phpcs` in the open workspace could be selected as the linter.

## Changed

- **LSP 3.18** — `vscode-languageclient`/`server` 9 → 10 ([#71](https://github.com/JohnRDOrazio/vscode-phpcs/pull/71)). No behavioural change; bundled server 292 KB → 312 KB.
- **`engines.node` → `>=22`** ([#76](https://github.com/JohnRDOrazio/vscode-phpcs/pull/76)), matching what the oldest supported VS Code actually runs (1.106.3 = Electron 37.7.0 = Node 22.20.0). VS Code does not enforce this field, so installation is unaffected.

## Not in the changelog, because it never reaches users

Dependabot with grouped updates and auto-merge, SHA-pinned actions, drift-proof branch protection, TypeScript 7 and full strict mode, the LSP protocol and resolver test suites, and a coverage job that can finally fail.

The two `serialize-javascript` advisories were **dev-scope** — the package reaches mocha's parallel-mode serialization, never the published bundle — so no released version was ever affected.

## Verification

Node 22.23.2: typecheck, `bundle`, 16 client + 236 server tests, and `vsce package` producing `vscode-phpcs-1.3.1.vsix` (206.85 KB).

All three `package.json` files are at 1.3.1 — `publish.yml` validates the tag against `phpcs/package.json` and fails the publish if they disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)